### PR TITLE
Add an example screenshotter using export-dmabuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = "1.0"
 
 [dev-dependencies]
 png = "0.17.5"
-smithay = { git = "https://github.com/Smithay/smithay" }
+smithay = { git = "https://github.com/Smithay/smithay", rev = "4d1d565", features = ["backend_drm", "backend_egl", "renderer_gl"] }
 
 [features]
 default = ["client", "server"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ wayland-client = { version = "0.30.0-beta.8", optional = true }
 wayland-server = { version = "0.30.0-beta.8", optional = true }
 bitflags = "1.0"
 
+[dev-dependencies]
+png = "0.17.5"
+smithay = { git = "https://github.com/Smithay/smithay" }
+
 [features]
 default = ["client", "server"]
 client = ["wayland-client", "wayland-protocols/client"]

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,0 +1,246 @@
+use cosmic_protocols::export_dmabuf::v1::client::{
+    zcosmic_export_dmabuf_frame_v1, zcosmic_export_dmabuf_manager_v1,
+};
+use smithay::{
+    backend::{
+        allocator::{
+            Fourcc, Modifier,
+            {
+                dmabuf::{Dmabuf, DmabufFlags},
+                gbm::GbmDevice,
+            },
+        },
+        drm::node::DrmNode,
+        egl::{context::EGLContext, display::EGLDisplay},
+        renderer::{gles2::Gles2Renderer, ExportMem, ImportDma, Texture},
+    },
+    utils::{Point, Rectangle},
+};
+use std::{collections::HashMap, fs, io, os::unix::io::RawFd};
+use wayland_client::{
+    protocol::{wl_output, wl_registry},
+    Connection, Dispatch, QueueHandle,
+};
+
+#[derive(Debug, Default)]
+struct Object {
+    fd: RawFd,
+    index: u32,
+    offset: u32,
+    stride: u32,
+    plane_index: u32,
+}
+
+#[derive(Debug, Default)]
+struct DmaBufFrame {
+    node: Option<DrmNode>,
+    width: u32,
+    height: u32,
+    objects: Vec<Object>,
+    modifier: Option<Modifier>,
+    format: Option<Fourcc>,
+    flags: Option<DmabufFlags>,
+    ready: bool,
+}
+
+#[derive(Default)]
+struct AppData {
+    export_dmabuf_manager: Option<zcosmic_export_dmabuf_manager_v1::ZcosmicExportDmabufManagerV1>,
+    outputs: Vec<(wl_output::WlOutput, String)>,
+    frames: HashMap<String, DmaBufFrame>,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<AppData>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version: _,
+        } = event
+        {
+            match interface.as_str() {
+                "zcosmic_export_dmabuf_manager_v1" => {
+                    app_data.export_dmabuf_manager = Some(registry
+                        .bind::<zcosmic_export_dmabuf_manager_v1::ZcosmicExportDmabufManagerV1, _, _>(
+                            name,
+                            1,
+                            qh,
+                            (),
+                        )
+                        .unwrap());
+                }
+                "wl_output" => {
+                    registry
+                        .bind::<wl_output::WlOutput, _, _>(name, 4, qh, ())
+                        .unwrap();
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_output::WlOutput, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        output: &wl_output::WlOutput,
+        event: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+        match event {
+            wl_output::Event::Name { name } => {
+                app_data.outputs.push((output.clone(), name));
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<zcosmic_export_dmabuf_manager_v1::ZcosmicExportDmabufManagerV1, ()> for AppData {
+    fn event(
+        _: &mut Self,
+        _: &zcosmic_export_dmabuf_manager_v1::ZcosmicExportDmabufManagerV1,
+        _: zcosmic_export_dmabuf_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+    }
+}
+
+impl Dispatch<zcosmic_export_dmabuf_frame_v1::ZcosmicExportDmabufFrameV1, String> for AppData {
+    fn event(
+        app_data: &mut Self,
+        _: &zcosmic_export_dmabuf_frame_v1::ZcosmicExportDmabufFrameV1,
+        event: zcosmic_export_dmabuf_frame_v1::Event,
+        output_name: &String,
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+        let mut frame = app_data.frames.entry(output_name.clone()).or_default();
+
+        match event {
+            zcosmic_export_dmabuf_frame_v1::Event::Device { ref node } => {
+                let node = u64::from_ne_bytes([
+                    node[0], node[1], node[2], node[3], node[4], node[5], node[6], node[7],
+                ]);
+                frame.node = Some(DrmNode::from_dev_id(node).unwrap());
+            }
+            zcosmic_export_dmabuf_frame_v1::Event::Frame {
+                width,
+                height,
+                mod_high,
+                mod_low,
+                format,
+                flags,
+                ..
+            } => {
+                frame.width = width;
+                frame.height = height;
+                frame.format = Some(Fourcc::try_from(format).unwrap());
+                frame.modifier = Some(Modifier::from(((mod_high as u64) << 32) + mod_low as u64));
+                frame.flags = Some(DmabufFlags::from_bits(u32::from(flags)).unwrap());
+            }
+            zcosmic_export_dmabuf_frame_v1::Event::Object {
+                fd,
+                index,
+                offset,
+                stride,
+                plane_index,
+                ..
+            } => {
+                assert!(plane_index == frame.objects.last().map_or(0, |x| x.plane_index + 1));
+                frame.objects.push(Object {
+                    fd,
+                    index,
+                    offset,
+                    stride,
+                    plane_index,
+                });
+            }
+            zcosmic_export_dmabuf_frame_v1::Event::Ready { .. } => {
+                frame.ready = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn main() {
+    let conn = Connection::connect_to_env().unwrap();
+    let display = conn.display();
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+    let _registry = display.get_registry(&qh, ()).unwrap();
+
+    let mut app_data = AppData::default();
+
+    event_queue.roundtrip(&mut app_data).unwrap();
+    event_queue.roundtrip(&mut app_data).unwrap();
+
+    let manager = app_data.export_dmabuf_manager.as_ref().unwrap();
+    for (output, name) in &app_data.outputs {
+        manager
+            .capture_output(0, output, &qh, name.clone())
+            .unwrap();
+    }
+
+    while app_data.frames.values().filter(|x| x.ready).count() < app_data.outputs.len() {
+        event_queue.blocking_dispatch(&mut app_data).unwrap();
+    }
+
+    for (k, v) in app_data.frames {
+        let drm_path = v.node.as_ref().unwrap().dev_path().unwrap();
+        let drm_file = fs::File::options()
+            .read(true)
+            .write(true)
+            .open(drm_path)
+            .unwrap();
+        let gbm = GbmDevice::new(drm_file).unwrap();
+        let display = EGLDisplay::new(&gbm, None).unwrap();
+        let context = EGLContext::new(&display, None).unwrap();
+
+        let mut builder = Dmabuf::builder(
+            (v.width as i32, v.height as i32),
+            v.format.unwrap(),
+            v.flags.unwrap(),
+        );
+        for object in v.objects {
+            builder.add_plane(
+                object.fd,
+                object.index,
+                object.offset,
+                object.stride,
+                v.modifier.unwrap(),
+            );
+        }
+        let dmabuf = builder.build().unwrap();
+
+        let mut renderer = unsafe { Gles2Renderer::new(context, None).unwrap() };
+        let texture = renderer.import_dmabuf(&dmabuf, None).unwrap();
+        let rectangle = Rectangle {
+            loc: Point::default(),
+            size: texture.size(),
+        };
+        let mapping = renderer.copy_texture(&texture, rectangle).unwrap();
+        let data = renderer.map_texture(&mapping).unwrap();
+
+        let path = format!("{}.png", k);
+        let file = io::BufWriter::new(fs::File::create(&path).unwrap());
+        let mut encoder = png::Encoder::new(file, v.width, v.height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().unwrap();
+        writer.write_image_data(&data).unwrap();
+        println!("Written image to '{}'.", path);
+    }
+}


### PR DESCRIPTION
This takes a screenshot for each display and saves to `.png` images.

I'm not entirely sure the dmabuf/OpenGL logic here handles formats. I assume OpenGL can be trusted to convert any DRM format to 8 bit per channel uncompressed RGBA? Which could be lossy depending on the format?

It could be good to have examples testing other protocols. And something testing dmabuf exporting for workspaces and toplevels. (It could similar iterate over workspaces and toplevels and export an image for each.)