### PR TITLE
feat: add focused as a toplevel state

### DIFF
--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -169,6 +169,7 @@
       <entry name="minimized"  value="1" summary="the toplevel is minimized"/>
       <entry name="activated"  value="2" summary="the toplevel is active"/>
       <entry name="fullscreen" value="3" summary="the toplevel is fullscreen"/>
+      <entry name="focused"    value="4" summary="the toplevel is focused"/>
     </enum>
 
     <event name="state">


### PR DESCRIPTION
This PR adds a focused state to `cosmic-toplevel-info-unstable`

This addition would be necessary for the visual app-list focus hint (https://github.com/pop-os/cosmic-applets/pull/328) and will also be required for click-to-minimize focused windows on the app-list (currently the system tries to track active toplevels per workspace but is not very robust)

The addition would require there to be reporting of focused toplevels in cosmic-comp, which I'm not super confident that I could do on my own.

@Drakulix questions for you, do I need to bump the version of `cosmic-toplevel-info-unstable`? And at some point would you be able to either give me guidance on or implement the tracking of this state in cosmic-comp?