### PR TITLE
Add `cosmic-keyboard-layout-unstable-v1` protocol

### DIFF
--- a/client-toolkit/Cargo.toml
+++ b/client-toolkit/Cargo.toml
@@ -22,6 +22,7 @@ smithay = { version = "0.7.0", default-features = false, features = [
     "renderer_gl",
     "backend_drm",
 ] }
+xkbcommon = "0.7.0"
 
 [features]
 default = []

--- a/client-toolkit/examples/keyboard_layout.rs
+++ b/client-toolkit/examples/keyboard_layout.rs
@@ -1,0 +1,226 @@
+use cosmic_client_toolkit::keyboard_layout::{KeyboardLayoutHandler, KeyboardLayoutState};
+use cosmic_protocols::keyboard_layout::v1::client::zcosmic_keyboard_layout_v1;
+use sctk::{
+    registry::{ProvidesRegistryState, RegistryState},
+    registry_handlers,
+    seat::{
+        Capability, SeatHandler, SeatState,
+        keyboard::{KeyEvent, KeyboardHandler, Keymap, Keysym, Modifiers, RawModifiers},
+    },
+};
+use std::{
+    io::{self, Write},
+    str::FromStr,
+};
+use wayland_client::{
+    Connection, QueueHandle,
+    globals::registry_queue_init,
+    protocol::{wl_keyboard, wl_seat, wl_surface},
+};
+use xkbcommon::xkb;
+
+struct AppData {
+    registry_state: RegistryState,
+    seat_state: SeatState,
+    keyboard: Option<wl_keyboard::WlKeyboard>,
+    keyboard_layout_state: KeyboardLayoutState,
+    keymap: Option<xkb::Keymap>,
+    group: Option<u32>,
+}
+
+impl ProvidesRegistryState for AppData {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+
+    registry_handlers![SeatState,];
+}
+
+impl SeatHandler for AppData {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+
+    fn new_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+
+    fn new_capability(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Keyboard {
+            let keyboard = self.seat_state.get_keyboard(qh, &seat, None).unwrap();
+            self.keyboard = Some(keyboard);
+        }
+    }
+
+    fn remove_capability(
+        &mut self,
+        _conn: &Connection,
+        _: &QueueHandle<Self>,
+        _: wl_seat::WlSeat,
+        _capability: Capability,
+    ) {
+    }
+
+    fn remove_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+}
+
+impl KeyboardHandler for AppData {
+    fn enter(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _surface: &wl_surface::WlSurface,
+        _: u32,
+        _: &[u32],
+        _keysyms: &[Keysym],
+    ) {
+    }
+
+    fn leave(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _surface: &wl_surface::WlSurface,
+        _: u32,
+    ) {
+    }
+
+    fn press_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        _event: KeyEvent,
+    ) {
+    }
+
+    fn repeat_key(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        _event: KeyEvent,
+    ) {
+    }
+
+    fn release_key(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        _event: KeyEvent,
+    ) {
+    }
+
+    fn update_modifiers(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        _modifiers: Modifiers,
+        _raw_modifiers: RawModifiers,
+        _layout: u32,
+    ) {
+    }
+
+    fn update_keymap(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        keymap: Keymap<'_>,
+    ) {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap = xkb::Keymap::new_from_string(
+            &context,
+            keymap.as_string(),
+            xkb::KEYMAP_FORMAT_TEXT_V1,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        )
+        .unwrap();
+        self.keymap = Some(keymap);
+    }
+}
+
+impl KeyboardLayoutHandler for AppData {
+    fn group(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _keyboard_layout: &zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1,
+        group: u32,
+    ) {
+        self.group = Some(group);
+    }
+}
+
+fn main() {
+    let conn = Connection::connect_to_env().unwrap();
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
+    let qh = event_queue.handle();
+
+    let registry_state = RegistryState::new(&globals);
+    let seat_state = SeatState::new(&globals, &qh);
+    let keyboard_layout_state = KeyboardLayoutState::new(&registry_state, &qh);
+    let mut app_data = AppData {
+        registry_state,
+        seat_state,
+        keyboard_layout_state,
+        keyboard: None,
+        keymap: None,
+        group: None,
+    };
+
+    while app_data.keymap.is_none() {
+        event_queue.blocking_dispatch(&mut app_data).unwrap();
+    }
+
+    let keyboard = app_data.keyboard.as_ref().unwrap();
+    let cosmic_keyboard_layout = app_data
+        .keyboard_layout_state
+        .get_keyboard_layout(&keyboard, &qh)
+        .unwrap();
+
+    while app_data.group.is_none() {
+        event_queue.blocking_dispatch(&mut app_data).unwrap();
+    }
+    let group = app_data.group.unwrap();
+
+    let keymap = app_data.keymap.as_ref().unwrap();
+    for (n, name) in keymap.layouts().enumerate() {
+        // Bold active layout
+        if n as u32 == group {
+            print!("\x1b[1m");
+        }
+        println!("{}: {}", n, name);
+        if n as u32 == group {
+            print!("\x1b[22m");
+        }
+    }
+    print!("Choose layout: ");
+
+    io::stdout().flush().unwrap();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line).unwrap();
+    let index = u32::from_str(line.trim()).unwrap();
+
+    cosmic_keyboard_layout.set_group(index);
+
+    event_queue.roundtrip(&mut app_data).unwrap();
+}
+
+sctk::delegate_registry!(AppData);
+sctk::delegate_seat!(AppData);
+sctk::delegate_keyboard!(AppData);
+cosmic_client_toolkit::delegate_keyboard_layout!(AppData);

--- a/client-toolkit/src/keyboard_layout.rs
+++ b/client-toolkit/src/keyboard_layout.rs
@@ -1,0 +1,118 @@
+use cosmic_protocols::keyboard_layout::v1::client::{
+    zcosmic_keyboard_layout_manager_v1, zcosmic_keyboard_layout_v1,
+};
+use sctk::registry::RegistryState;
+use wayland_client::{Connection, Dispatch, QueueHandle, protocol::wl_keyboard};
+
+pub trait KeyboardLayoutHandler: Sized {
+    fn group(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        keyboard: &wl_keyboard::WlKeyboard,
+        keyboard_layout: &zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1,
+        group: u32,
+    );
+}
+
+pub struct KeyboardLayoutState {
+    pub keyboard_layout_manager:
+        Option<zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1>,
+}
+
+impl KeyboardLayoutState {
+    pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
+    where
+        D: Dispatch<zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1, ()>
+            + 'static,
+    {
+        let keyboard_layout_manager = registry
+            .bind_one::<zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1, _, _>(
+                qh,
+                1..=1,
+                (),
+            )
+            .ok();
+
+        Self {
+            keyboard_layout_manager,
+        }
+    }
+
+    pub fn get_keyboard_layout<D>(
+        &self,
+        keyboard: &wl_keyboard::WlKeyboard,
+        qh: &QueueHandle<D>,
+    ) -> Option<zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1>
+    where
+        D: Dispatch<zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1, KeyboardLayoutUserData>
+            + 'static,
+    {
+        Some(self.keyboard_layout_manager.as_ref()?.get_keyboard_layout(
+            keyboard,
+            qh,
+            KeyboardLayoutUserData {
+                keyboard: keyboard.clone(),
+            },
+        ))
+    }
+}
+
+impl<D> Dispatch<zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1, (), D>
+    for KeyboardLayoutState
+where
+    D: Dispatch<zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1, ()>,
+{
+    fn event(
+        _: &mut D,
+        _: &zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1,
+        event: zcosmic_keyboard_layout_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        match event {
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct KeyboardLayoutUserData {
+    keyboard: wl_keyboard::WlKeyboard,
+}
+
+impl<D> Dispatch<zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1, KeyboardLayoutUserData, D>
+    for KeyboardLayoutState
+where
+    D: Dispatch<zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1, KeyboardLayoutUserData>
+        + KeyboardLayoutHandler,
+{
+    fn event(
+        state: &mut D,
+        keyboard_layout: &zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1,
+        event: zcosmic_keyboard_layout_v1::Event,
+        data: &KeyboardLayoutUserData,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            zcosmic_keyboard_layout_v1::Event::Group { group } => {
+                state.group(conn, qh, &data.keyboard, keyboard_layout, group);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_keyboard_layout {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::keyboard_layout::v1::client::zcosmic_keyboard_layout_manager_v1::ZcosmicKeyboardLayoutManagerV1: ()
+        ] => $crate::keyboard_layout::KeyboardLayoutState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::keyboard_layout::v1::client::zcosmic_keyboard_layout_v1::ZcosmicKeyboardLayoutV1: $crate::keyboard_layout::KeyboardLayoutUserData
+        ] => $crate::keyboard_layout::KeyboardLayoutState);
+    };
+}

--- a/client-toolkit/src/lib.rs
+++ b/client-toolkit/src/lib.rs
@@ -3,6 +3,7 @@ pub use sctk;
 pub use wayland_client;
 pub use wayland_protocols;
 
+pub mod keyboard_layout;
 pub mod screencopy;
 pub mod toplevel_info;
 pub mod toplevel_management;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,3 +121,15 @@ pub mod workspace {
         );
     }
 }
+
+pub mod keyboard_layout {
+    //! Set keymap group.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./unstable/cosmic-keyboard-layout-unstable-v1.xml",
+            []
+        );
+    }
+}

--- a/unstable/cosmic-keyboard-layout-unstable-v1.xml
+++ b/unstable/cosmic-keyboard-layout-unstable-v1.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cosmic_keyboard_layout_unstable_v1">
+  <copyright>
+    Copyright © 2026 System76, Inc
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol to control keyboard layout group">
+    This protocol notifies clients of the active keyboard layout group, and allows
+    setting a new value.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="zcosmic_keyboard_layout_manager_v1" version="1">
+    <description summary="keyboard layout manager">
+      Manager for creating `zcosmic_keyboard_layout_v1` instances.
+    </description>
+
+    <request name="get_keyboard_layout">
+      <description summary="Get keyboard layout object">
+        Create a `zcosmic_keyboard_layout_v1` to get and set group for given keyboard.
+      </description>
+      <arg name="keyboard_layout" type="new_id" interface="zcosmic_keyboard_layout_v1"/>
+      <arg name="keyboard" type="object" interface="wl_keyboard"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zcosmic_keyboard_layout_v1" version="1">
+    <description summary="">
+      Object to get and set `group` for a particular `wl_keyboard`.
+    </description>
+
+    <event name="group">
+      <description summary="layout group changed">
+        Unlike `wl_keyboard::modifiers`, this event is received even when the client has no focused window.
+      </description>
+      <arg name="group" type="uint"/>
+    </event>
+
+    <request name="set_group">
+      <description summary="set layout group">
+        On success, the `group` event will be generated for all clients, and the focused client will
+        receive `wl_keyboard::modifiers` with the new group.
+
+        The request will be ignored if `group` is out of bounds.
+      </description>
+      <arg name="group" type="uint"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+      </description>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
Includes example client using `cosmic-client-toolkit`.

https://github.com/pop-os/cosmic-applets/tree/master/cosmic-applet-input-sources sets the keyboard layout by modifying `xkb_config`. But it should instead leave the keymap unchanged, and change the group. The applet also doesn't recognize when the group is changed by something else.

KDE has a DBus protocol for this (https://invent.kde.org/plasma/plasma-workspace/-/blob/master/components/keyboardlayout/org.kde.KeyboardLayouts.xml?ref_type=heads). We could have one, but a Wayland protocol is easier to integrate into the compositor, and lets us just use `wl_keyboard.keymap` to get the current keymap and list of layouts. And privileged Wayland protocols match how our applets typically work.

Zbus is however a bit less verbose that adding a wayland protocol.... something we should work on (https://github.com/Smithay/smithay/pull/1327, etc.).

I guess this will also need an event for the active group, since `modifiers` (unlike `keymap)` is only being sent to focused windows).