### PR TITLE
toplevel-info: Add missing since attribute

### DIFF
--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -78,7 +78,7 @@
       </description>
     </event>
 
-    <request name="get_cosmic_toplevel">
+    <request name="get_cosmic_toplevel" since="2">
       <description summary="get cosmic toplevel extension object">
         Request a zcosmic_toplevel_handle_v1 extension object for an existing
         ext_foreign_toplevel_handle_v1.


### PR DESCRIPTION
We don't support foreign-toplevel-list on v1, this was simply missing from https://github.com/pop-os/cosmic-protocols/pull/29