### PR TITLE
add cosmic workspace protocol v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ unstable_protocols = \
 	unstable/cosmic-toplevel-info-unstable-v1.xml \
 	unstable/cosmic-toplevel-management-unstable-v1.xml \
 	unstable/cosmic-overlap-notify-unstable-v1.xml \
-	unstable/cosmic-workspace-unstable-v1.xml \
+	unstable/cosmic-workspace-unstable-v2.xml \
 
 check: $(unstable_protocols)
 	./check.sh $(unstable_protocols)

--- a/client-toolkit/examples/iced-capture.rs
+++ b/client-toolkit/examples/iced-capture.rs
@@ -9,7 +9,7 @@ use cosmic_client_toolkit::{
 };
 use cosmic_protocols::{
     screencopy::v1::client::{zcosmic_screencopy_manager_v1, zcosmic_screencopy_session_v1},
-    workspace::v1::client::zcosmic_workspace_group_handle_v1,
+    workspace::v2::client::zcosmic_workspace_group_handle_v2,
 };
 use futures::{
     channel::mpsc,

--- a/client-toolkit/src/screencopy.rs
+++ b/client-toolkit/src/screencopy.rs
@@ -3,7 +3,7 @@
 use cosmic_protocols::{
     image_source::v1::client::{
         zcosmic_image_source_v1, zcosmic_output_image_source_manager_v1,
-        zcosmic_toplevel_image_source_manager_v1, zcosmic_workspace_image_source_manager_v1,
+        zcosmic_toplevel_image_source_manager_v1, zcosmic_workspace_image_source_manager_v2,
     },
     screencopy::v2::client::{
         zcosmic_screencopy_frame_v2, zcosmic_screencopy_manager_v2, zcosmic_screencopy_session_v2,
@@ -84,7 +84,7 @@ pub struct ScreencopyState {
     pub toplevel_source_manager:
         Option<zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1>,
     pub workspace_source_manager:
-        Option<zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1>,
+        Option<zcosmic_workspace_image_source_manager_v2::ZcosmicWorkspaceImageSourceManagerV2>,
 }
 
 impl ScreencopyState {
@@ -98,7 +98,7 @@ impl ScreencopyState {
             (),
         >,
         D: Dispatch<
-            zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
+            zcosmic_workspace_image_source_manager_v2::ZcosmicWorkspaceImageSourceManagerV2,
             (),
         >,
     {
@@ -357,18 +357,18 @@ where
 }
 
 impl<D>
-    Dispatch<zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1, (), D>
+    Dispatch<zcosmic_workspace_image_source_manager_v2::ZcosmicWorkspaceImageSourceManagerV2, (), D>
     for ScreencopyState
 where
     D: Dispatch<
-            zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
+            zcosmic_workspace_image_source_manager_v2::ZcosmicWorkspaceImageSourceManagerV2,
             (),
         > + ScreencopyHandler,
 {
     fn event(
         app_data: &mut D,
-        source: &zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
-        event: zcosmic_workspace_image_source_manager_v1::Event,
+        source: &zcosmic_workspace_image_source_manager_v2::ZcosmicWorkspaceImageSourceManagerV2,
+        event: zcosmic_workspace_image_source_manager_v2::Event,
         udata: &(),
         conn: &Connection,
         qh: &QueueHandle<D>,
@@ -391,7 +391,7 @@ macro_rules! delegate_screencopy {
             $crate::cosmic_protocols::image_source::v1::client::zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1: ()
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::image_source::v1::client::zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1: ()
+            $crate::cosmic_protocols::image_source::v1::client::zcosmic_workspace_image_source_manager_v2::ZcosmicWorkspaceImageSourceManagerV1: ()
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::cosmic_protocols::image_source::v1::client::zcosmic_image_source_v1::ZcosmicImageSourceV1: ()

--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use cosmic_protocols::{
     toplevel_info::v1::client::{zcosmic_toplevel_handle_v1, zcosmic_toplevel_info_v1},
-    workspace::v1::client::zcosmic_workspace_handle_v1,
+    workspace::v2::client::zcosmic_workspace_handle_v2,
 };
 use sctk::registry::RegistryState;
 use wayland_client::{protocol::wl_output, Connection, Dispatch, QueueHandle};
@@ -13,7 +13,7 @@ pub struct ToplevelInfo {
     pub app_id: String,
     pub state: HashSet<zcosmic_toplevel_handle_v1::State>,
     pub output: HashSet<wl_output::WlOutput>,
-    pub workspace: HashSet<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1>,
+    pub workspace: HashSet<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2>,
 }
 
 #[derive(Debug, Default)]

--- a/client-toolkit/src/workspace.rs
+++ b/client-toolkit/src/workspace.rs
@@ -1,38 +1,38 @@
-use cosmic_protocols::workspace::v1::client::{
-    zcosmic_workspace_group_handle_v1, zcosmic_workspace_handle_v1, zcosmic_workspace_manager_v1,
+use cosmic_protocols::workspace::v2::client::{
+    zcosmic_workspace_group_handle_v2, zcosmic_workspace_handle_v2, zcosmic_workspace_manager_v2,
 };
 use sctk::registry::{GlobalProxy, RegistryState};
 use wayland_client::{protocol::wl_output, Connection, Dispatch, QueueHandle, WEnum};
 
 #[derive(Clone, Debug)]
 pub struct WorkspaceGroup {
-    pub handle: zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
+    pub handle: zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2,
     pub capabilities:
-        Vec<WEnum<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupCapabilitiesV1>>,
+        Vec<WEnum<zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupCapabilitiesV2>>,
     pub outputs: Vec<wl_output::WlOutput>,
     pub workspaces: Vec<Workspace>,
 }
 
 #[derive(Clone, Debug)]
 pub struct Workspace {
-    pub handle: zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
+    pub handle: zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2,
     pub name: String,
     pub coordinates: Vec<u32>,
-    pub state: Vec<WEnum<zcosmic_workspace_handle_v1::State>>,
-    pub capabilities: Vec<WEnum<zcosmic_workspace_handle_v1::ZcosmicWorkspaceCapabilitiesV1>>,
-    pub tiling: Option<WEnum<zcosmic_workspace_handle_v1::TilingState>>,
+    pub state: Vec<WEnum<zcosmic_workspace_handle_v2::State>>,
+    pub capabilities: Vec<WEnum<zcosmic_workspace_handle_v2::ZcosmicWorkspaceCapabilitiesV2>>,
+    pub tiling: Option<WEnum<zcosmic_workspace_handle_v2::TilingState>>,
 }
 
 #[derive(Debug)]
 pub struct WorkspaceState {
     workspace_groups: Vec<WorkspaceGroup>,
-    manager: GlobalProxy<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1>,
+    manager: GlobalProxy<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2>,
 }
 
 impl WorkspaceState {
     pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
     where
-        D: Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, ()> + 'static,
+        D: Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, ()> + 'static,
     {
         Self {
             workspace_groups: Vec::new(),
@@ -42,7 +42,7 @@ impl WorkspaceState {
 
     pub fn workspace_manager(
         &self,
-    ) -> &GlobalProxy<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1> {
+    ) -> &GlobalProxy<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2> {
         &self.manager
     }
 
@@ -58,23 +58,23 @@ pub trait WorkspaceHandler {
     fn done(&mut self);
 }
 
-impl<D> Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, (), D> for WorkspaceState
+impl<D> Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, (), D> for WorkspaceState
 where
-    D: Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, ()>
-        + Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, ()>
+    D: Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, ()>
+        + Dispatch<zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, ()>
         + WorkspaceHandler
         + 'static,
 {
     fn event(
         state: &mut D,
-        _: &zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1,
-        event: zcosmic_workspace_manager_v1::Event,
+        _: &zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2,
+        event: zcosmic_workspace_manager_v2::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
         match event {
-            zcosmic_workspace_manager_v1::Event::WorkspaceGroup { workspace_group } => {
+            zcosmic_workspace_manager_v2::Event::WorkspaceGroup { workspace_group } => {
                 state
                     .workspace_state()
                     .workspace_groups
@@ -85,31 +85,31 @@ where
                         workspaces: Vec::new(),
                     });
             }
-            zcosmic_workspace_manager_v1::Event::Done => {
+            zcosmic_workspace_manager_v2::Event::Done => {
                 state.done();
             }
-            zcosmic_workspace_manager_v1::Event::Finished => {}
+            zcosmic_workspace_manager_v2::Event::Finished => {}
             _ => unreachable!(),
         }
     }
 
-    wayland_client::event_created_child!(D, zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, [
-        zcosmic_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE => (zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, ())
+    wayland_client::event_created_child!(D, zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, [
+        zcosmic_workspace_manager_v2::EVT_WORKSPACE_GROUP_OPCODE => (zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, ())
     ]);
 }
 
-impl<D> Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, (), D>
+impl<D> Dispatch<zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, (), D>
     for WorkspaceState
 where
-    D: Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, ()>
-        + Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, ()>
+    D: Dispatch<zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, ()>
+        + Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, ()>
         + WorkspaceHandler
         + 'static,
 {
     fn event(
         state: &mut D,
-        handle: &zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
-        event: zcosmic_workspace_group_handle_v1::Event,
+        handle: &zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2,
+        event: zcosmic_workspace_group_handle_v2::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<D>,
@@ -121,21 +121,21 @@ where
             .find(|group| &group.handle == handle)
             .unwrap();
         match event {
-            zcosmic_workspace_group_handle_v1::Event::Capabilities { capabilities } => {
+            zcosmic_workspace_group_handle_v2::Event::Capabilities { capabilities } => {
                 group.capabilities = capabilities
                     .chunks(4)
                     .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
                     .collect();
             }
-            zcosmic_workspace_group_handle_v1::Event::OutputEnter { output } => {
+            zcosmic_workspace_group_handle_v2::Event::OutputEnter { output } => {
                 group.outputs.push(output);
             }
-            zcosmic_workspace_group_handle_v1::Event::OutputLeave { output } => {
+            zcosmic_workspace_group_handle_v2::Event::OutputLeave { output } => {
                 if let Some(idx) = group.outputs.iter().position(|x| x == &output) {
                     group.outputs.remove(idx);
                 }
             }
-            zcosmic_workspace_group_handle_v1::Event::Workspace { workspace } => {
+            zcosmic_workspace_group_handle_v2::Event::Workspace { workspace } => {
                 group.workspaces.push(Workspace {
                     handle: workspace,
                     name: String::new(),
@@ -145,7 +145,7 @@ where
                     tiling: None,
                 });
             }
-            zcosmic_workspace_group_handle_v1::Event::Remove => {
+            zcosmic_workspace_group_handle_v2::Event::Destroyed => {
                 if let Some(idx) = state
                     .workspace_state()
                     .workspace_groups
@@ -159,19 +159,19 @@ where
         }
     }
 
-    wayland_client::event_created_child!(D, zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, [
-        zcosmic_workspace_group_handle_v1::EVT_WORKSPACE_OPCODE => (zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, ())
+    wayland_client::event_created_child!(D, zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, [
+        zcosmic_workspace_group_handle_v2::EVT_WORKSPACE_OPCODE => (zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, ())
     ]);
 }
 
-impl<D> Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, (), D> for WorkspaceState
+impl<D> Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, (), D> for WorkspaceState
 where
-    D: Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, ()> + WorkspaceHandler,
+    D: Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, ()> + WorkspaceHandler,
 {
     fn event(
         state: &mut D,
-        handle: &zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
-        event: zcosmic_workspace_handle_v1::Event,
+        handle: &zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2,
+        event: zcosmic_workspace_handle_v2::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<D>,
@@ -183,31 +183,31 @@ where
             .find_map(|group| group.workspaces.iter_mut().find(|w| &w.handle == handle))
             .unwrap();
         match event {
-            zcosmic_workspace_handle_v1::Event::Name { name } => {
+            zcosmic_workspace_handle_v2::Event::Name { name } => {
                 workspace.name = name;
             }
-            zcosmic_workspace_handle_v1::Event::Coordinates { coordinates } => {
+            zcosmic_workspace_handle_v2::Event::Coordinates { coordinates } => {
                 workspace.coordinates = coordinates
                     .chunks(4)
                     .map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
                     .collect();
             }
-            zcosmic_workspace_handle_v1::Event::State { state } => {
+            zcosmic_workspace_handle_v2::Event::State { state } => {
                 workspace.state = state
                     .chunks(4)
                     .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
                     .collect();
             }
-            zcosmic_workspace_handle_v1::Event::Capabilities { capabilities } => {
+            zcosmic_workspace_handle_v2::Event::Capabilities { capabilities } => {
                 workspace.capabilities = capabilities
                     .chunks(4)
                     .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
                     .collect();
             }
-            zcosmic_workspace_handle_v1::Event::TilingState { state } => {
+            zcosmic_workspace_handle_v2::Event::TilingState { state } => {
                 workspace.tiling = Some(state);
             }
-            zcosmic_workspace_handle_v1::Event::Remove => {
+            zcosmic_workspace_handle_v2::Event::Destroyed => {
                 for group in state.workspace_state().workspace_groups.iter_mut() {
                     if let Some(idx) = group.workspaces.iter().position(|w| &w.handle == handle) {
                         group.workspaces.remove(idx);
@@ -223,13 +223,13 @@ where
 macro_rules! delegate_workspace {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::workspace::v1::client::zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1: ()
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2: ()
         ] => $crate::workspace::WorkspaceState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::workspace::v1::client::zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1: ()
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2: ()
         ] => $crate::workspace::WorkspaceState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::workspace::v1::client::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1: ()
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2: ()
         ] => $crate::workspace::WorkspaceState);
     };
 }

--- a/examples/toplevel-list.rs
+++ b/examples/toplevel-list.rs
@@ -1,8 +1,8 @@
 use cosmic_protocols::{
     toplevel_info::v1::client::{zcosmic_toplevel_handle_v1, zcosmic_toplevel_info_v1},
-    workspace::v1::client::{
-        zcosmic_workspace_group_handle_v1, zcosmic_workspace_handle_v1,
-        zcosmic_workspace_manager_v1,
+    workspace::v2::client::{
+        zcosmic_workspace_group_handle_v2, zcosmic_workspace_handle_v2,
+        zcosmic_workspace_manager_v2,
     },
 };
 use wayland_client::{
@@ -14,13 +14,13 @@ use wayland_client::{
 #[derive(Default)]
 struct AppData {
     toplevel_info: Option<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1>,
-    workspace_manager: Option<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1>,
+    workspace_manager: Option<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2>,
     outputs: Vec<(wl_output::WlOutput, String)>,
     toplevels: Vec<Toplevel>,
     workspaces: Vec<(
-        zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
+        zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2,
         Vec<(
-            zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
+            zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2,
             Option<String>,
         )>,
     )>,
@@ -31,7 +31,7 @@ struct Toplevel {
     title: Option<String>,
     app_id: Option<String>,
     outputs: Vec<wl_output::WlOutput>,
-    workspaces: Vec<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1>,
+    workspaces: Vec<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2>,
     state: Vec<State>,
 }
 
@@ -83,10 +83,10 @@ impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
                         ),
                     );
                 }
-                "zcosmic_workspace_manager_v1" => {
+                "zcosmic_workspace_manager_v2" => {
                     app_data.workspace_manager = Some(
                         registry
-                            .bind::<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, _, _>(
+                            .bind::<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, _, _>(
                                 name,
                                 1,
                                 qh,
@@ -236,17 +236,17 @@ impl Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()> for AppDa
     }
 }
 
-impl Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, ()> for AppData {
+impl Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, ()> for AppData {
     fn event(
         app_data: &mut Self,
-        _: &zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1,
-        event: zcosmic_workspace_manager_v1::Event,
+        _: &zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2,
+        event: zcosmic_workspace_manager_v2::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<AppData>,
     ) {
         match event {
-            zcosmic_workspace_manager_v1::Event::WorkspaceGroup { workspace_group } => {
+            zcosmic_workspace_manager_v2::Event::WorkspaceGroup { workspace_group } => {
                 app_data.workspaces.push((workspace_group, Vec::new()));
             }
             _ => {}
@@ -255,24 +255,24 @@ impl Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, ()> for A
 
     event_created_child!(
         AppData,
-        zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1,
+        zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2,
         [
-            zcosmic_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE => (zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, ()),
+            zcosmic_workspace_manager_v2::EVT_WORKSPACE_GROUP_OPCODE => (zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, ()),
         ]
     );
 }
 
-impl Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, ()> for AppData {
+impl Dispatch<zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2, ()> for AppData {
     fn event(
         app_data: &mut AppData,
-        group: &zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
-        event: <zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1 as Proxy>::Event,
+        group: &zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2,
+        event: <zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2 as Proxy>::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
         match event {
-            zcosmic_workspace_group_handle_v1::Event::Workspace { workspace } => {
+            zcosmic_workspace_group_handle_v2::Event::Workspace { workspace } => {
                 if let Some((_, spaces)) = app_data.workspaces.iter_mut().find(|(g, _)| g == group)
                 {
                     spaces.push((workspace, None));
@@ -284,24 +284,24 @@ impl Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, 
 
     event_created_child!(
         AppData,
-        zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
+        zcosmic_workspace_group_handle_v2::ZcosmicWorkspaceGroupHandleV2,
         [
-            zcosmic_workspace_group_handle_v1::EVT_WORKSPACE_OPCODE => (zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, ()),
+            zcosmic_workspace_group_handle_v2::EVT_WORKSPACE_OPCODE => (zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, ()),
         ]
     );
 }
 
-impl Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, ()> for AppData {
+impl Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, ()> for AppData {
     fn event(
         app_data: &mut AppData,
-        workspace: &zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
-        event: <zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1 as Proxy>::Event,
+        workspace: &zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2,
+        event: <zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2 as Proxy>::Event,
         _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
         match event {
-            zcosmic_workspace_handle_v1::Event::Name { name } => {
+            zcosmic_workspace_handle_v2::Event::Name { name } => {
                 if let Some((_, n)) = app_data
                     .workspaces
                     .iter_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod image_source {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-image-source-unstable-v1.xml",
-            [crate::workspace::v1, crate::toplevel_info::v1]
+            [crate::workspace::v2, crate::toplevel_info::v1]
         );
     }
 }
@@ -60,7 +60,7 @@ pub mod toplevel_info {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-toplevel-info-unstable-v1.xml",
-            [crate::workspace::v1, wayland_protocols::ext::foreign_toplevel_list::v1]
+            [crate::workspace::v2, wayland_protocols::ext::foreign_toplevel_list::v1]
         );
     }
 }
@@ -72,7 +72,7 @@ pub mod toplevel_management {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-toplevel-management-unstable-v1.xml",
-            [crate::toplevel_info::v1, crate::workspace::v1]
+            [crate::toplevel_info::v1, crate::workspace::v2]
         );
     }
 }
@@ -93,9 +93,9 @@ pub mod workspace {
     //! Receive information about and control workspaces.
 
     #[allow(missing_docs)]
-    pub mod v1 {
+    pub mod v2 {
         wayland_protocol!(
-            "./unstable/cosmic-workspace-unstable-v1.xml",
+            "./unstable/cosmic-workspace-unstable-v2.xml",
             []
         );
     }

--- a/unstable/cosmic-image-source-unstable-v1.xml
+++ b/unstable/cosmic-image-source-unstable-v1.xml
@@ -82,7 +82,7 @@
     </request>
   </interface>
 
-  <interface name="zcosmic_workspace_image_source_manager_v1" version="1">
+  <interface name="zcosmic_workspace_image_source_manager_v2" version="1">
     <description summary="image source manager for outputs">
       A manager for creating image source objects for wl_output objects.
     </description>
@@ -95,7 +95,7 @@
         capturing.
       </description>
       <arg name="source" type="new_id" interface="zcosmic_image_source_v1"/>
-      <arg name="output" type="object" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="output" type="object" interface="zcosmic_workspace_handle_v2"/>
     </request>
 
     <request name="destroy" type="destructor">
@@ -131,4 +131,3 @@
     </request>
   </interface>
 </protocol>
-

--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -193,7 +193,7 @@
         This event is emitted whenever the toplevel becomes visible on the
         given workspace. A toplevel may be visible on multiple workspaces.
       </description>
-      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v2"/>
     </event>
 
     <event name="workspace_leave">
@@ -202,7 +202,7 @@
         on a given workspace. It is guaranteed that an workspace_enter event with
         the same workspace has been emitted before this event.
       </description>
-      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v2"/>
     </event>
 
     <enum name="state">

--- a/unstable/cosmic-toplevel-management-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-management-unstable-v1.xml
@@ -174,7 +174,7 @@
         Move window to workspace, on given output.
       </description>
       <arg name="toplevel" type="object" interface="zcosmic_toplevel_handle_v1"/>
-      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v2"/>
       <arg name="output" type="object" interface="wl_output"/>
     </request>
 

--- a/unstable/cosmic-workspace-unstable-v2.xml
+++ b/unstable/cosmic-workspace-unstable-v2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<protocol name="cosmic_workspace_unstable_v1">
+<protocol name="cosmic_workspace_unstable_v2">
   <copyright>
     Copyright © 2019 Christopher Billington
     Copyright © 2020 Ilia Bozhinov
@@ -27,7 +27,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zcosmic_workspace_manager_v1" version="2">
+  <interface name="zcosmic_workspace_manager_v2" version="2">
     <description summary="list and control workspaces">
       Workspaces, also called virtual desktops, are groups of surfaces. A
       compositor with a concept of workspaces may only show some such groups of
@@ -46,7 +46,7 @@
       docks by providing them with a list of workspaces and their properties,
       and allowing them to activate and deactivate workspaces.
 
-      After a client binds the zcosmic_workspace_manager_v1, each workspace will be
+      After a client binds the zcosmic_workspace_manager_v2, each workspace will be
       sent via the workspace event.
     </description>
 
@@ -56,9 +56,9 @@
 
         All initial details of the workspace group (workspaces, outputs) will be
         sent immediately after this event via the corresponding events in
-        zcosmic_workspace_group_handle_v1.
+        zcosmic_workspace_group_handle_v2.
       </description>
-      <arg name="workspace_group" type="new_id" interface="zcosmic_workspace_group_handle_v1"/>
+      <arg name="workspace_group" type="new_id" interface="zcosmic_workspace_group_handle_v2"/>
     </event>
 
     <request name="commit">
@@ -69,7 +69,7 @@
 
         This allows changes to the workspace properties to be seen as atomic,
         even if they happen via multiple events, and even if they involve
-        multiple zcosmic_workspace_handle_v1 objects, for example, deactivating one
+        multiple zcosmic_workspace_handle_v2 objects, for example, deactivating one
         workspace and activating another.
       </description>
     </request>
@@ -79,12 +79,12 @@
         This event is sent after all changes in all workspace groups have been
         sent.
 
-        This allows changes to one or more zcosmic_workspace_group_handle_v1
-        properties and zcosmic_workspace_handle_v1 properties to be seen as atomic,
+        This allows changes to one or more zcosmic_workspace_group_handle_v2
+        properties and zcosmic_workspace_handle_v2 properties to be seen as atomic,
         even if they happen via multiple events.
         In particular, an output moving from one workspace group to
         another sends an output_enter event and an output_leave event to the two
-        zcosmic_workspace_group_handle_v1 objects in question. The compositor sends
+        zcosmic_workspace_group_handle_v2 objects in question. The compositor sends
         the done event only after updating the output information in both
         workspace groups.
       </description>
@@ -93,7 +93,7 @@
     <event name="finished">
       <description summary="the compositor has finished with the workspace_manager">
         This event indicates that the compositor is done sending events to the
-        zcosmic_workspace_manager_v1. The server will destroy the object
+        zcosmic_workspace_manager_v2. The server will destroy the object
         immediately after sending this request, so it will become invalid and
         the client should free any resources associated with it.
       </description>
@@ -110,9 +110,9 @@
     </request>
   </interface>
 
-  <interface name="zcosmic_workspace_group_handle_v1" version="2">
+  <interface name="zcosmic_workspace_group_handle_v2" version="2">
     <description summary="a workspace group assigned to a set of outputs">
-      A zcosmic_workspace_group_handle_v1 object represents a a workspace group
+      A zcosmic_workspace_group_handle_v2 object represents a a workspace group
       that is assigned a set of outputs and contains a number of workspaces.
 
       The set of outputs assigned to the workspace group is conveyed to the client via
@@ -125,7 +125,7 @@
       outputs.
     </description>
 
-    <enum name="zcosmic_workspace_group_capabilities_v1">
+    <enum name="zcosmic_workspace_group_capabilities_v2">
       <entry name="create_workspace" value="1" summary="create_workspace request is available"/>
     </enum>
 
@@ -142,7 +142,7 @@
         create_workspace requests.
 
         Compositors must send this event once after creation of an
-        zcosmic_workspace_group_handle_v1 . When the capabilities change, compositors
+        zcosmic_workspace_group_handle_v2 . When the capabilities change, compositors
         must send this event again.
 
         The capabilities are sent as an array of 32-bit unsigned integers in
@@ -175,16 +175,16 @@
 
         All initial details of the workspace (name, coordinates, state) will
         be sent immediately after this event via the corresponding events in
-        zcosmic_workspace_handle_v1.
+        zcosmic_workspace_handle_v2.
       </description>
-      <arg name="workspace" type="new_id" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="workspace" type="new_id" interface="zcosmic_workspace_handle_v2"/>
     </event>
 
-    <event name="remove">
+    <event name="destroyed">
       <description summary="this workspace group has been destroyed">
-        This event means the zcosmic_workspace_group_handle_v1 has been destroyed.
+        This event means the zcosmic_workspace_group_handle_v2 has been destroyed.
         It is guaranteed there won't be any more events for this
-        zcosmic_workspace_group_handle_v1. The zext_workspace_group_handle_v1 becomes
+        zcosmic_workspace_group_handle_v2. The zext_workspace_group_handle_v2 becomes
         inert so any requests will be ignored except the destroy request.
 
         The compositor must remove all workspaces belonging to a workspace group
@@ -203,8 +203,8 @@
     </request>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy the zcosmic_workspace_group_handle_v1 object">
-        Destroys the zcosmic_workspace_group_handle_v1 object.
+      <description summary="destroy the zcosmic_workspace_group_handle_v2 object">
+        Destroys the zcosmic_workspace_group_handle_v2 object.
 
         This request should be called either when the client does not want to
         use the workspace object any more or after the remove event to finalize
@@ -213,9 +213,9 @@
     </request>
   </interface>
 
-  <interface name="zcosmic_workspace_handle_v1" version="2">
+  <interface name="zcosmic_workspace_handle_v2" version="2">
     <description summary="a workspace handing a group of surfaces">
-      A zcosmic_workspace_handle_v1 object represents a a workspace that handles a
+      A zcosmic_workspace_handle_v2 object represents a a workspace that handles a
       group of surfaces.
 
       Each workspace has a name, conveyed to the client with the name event; a
@@ -232,7 +232,7 @@
 
     <event name="name">
       <description summary="workspace name changed">
-        This event is emitted immediately after the zcosmic_workspace_handle_v1 is
+        This event is emitted immediately after the zcosmic_workspace_handle_v2 is
         created and whenever the name of the workspace changes.
       </description>
       <arg name="name" type="string"/>
@@ -242,7 +242,7 @@
       <description summary="workspace coordinates changed">
         This event is used to organize workspaces into an N-dimensional grid
         within a workspace group, and if supported, is emitted immediately after
-        the zcosmic_workspace_handle_v1 is created and whenever the coordinates of
+        the zcosmic_workspace_handle_v2 is created and whenever the coordinates of
         the workspace change. Compositors may not send this event if they do not
         conceptually arrange workspaces in this way. If compositors simply
         number workspaces, without any geometric interpretation, they may send
@@ -264,7 +264,7 @@
 
     <event name="state">
       <description summary="the state of the workspace changed">
-        This event is emitted immediately after the zcosmic_workspace_handle_v1 is
+        This event is emitted immediately after the zcosmic_workspace_handle_v2 is
         created and each time the workspace state changes, either because of a
         compositor action or because of a request in this protocol.
       </description>
@@ -287,7 +287,7 @@
       </entry>
     </enum>
 
-    <enum name="zcosmic_workspace_capabilities_v1">
+    <enum name="zcosmic_workspace_capabilities_v2">
       <entry name="activate" value="1" summary="activate request is available"/>
       <entry name="deactivate" value="2" summary="deactivate request is available"/>
       <entry name="remove" value="3" summary="remove request is available"/>
@@ -308,7 +308,7 @@
         remove requests.
 
         Compositors must send this event once after creation of an
-        zcosmic_workspace_handle_v1 . When the capabilities change, compositors
+        zcosmic_workspace_handle_v2 . When the capabilities change, compositors
         must send this event again.
 
         The capabilities are sent as an array of 32-bit unsigned integers in
@@ -317,18 +317,18 @@
       <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
     </event>
 
-    <event name="remove">
+    <event name="destroyed">
       <description summary="this workspace has been destroyed">
-        This event means the zcosmic_workspace_handle_v1 has been destroyed. It is
+        This event means the zcosmic_workspace_handle_v2 has been destroyed. It is
         guaranteed there won't be any more events for this
-        zcosmic_workspace_handle_v1. The zext_workspace_handle_v1 becomes inert so
+        zcosmic_workspace_handle_v2. The zext_workspace_handle_v2 becomes inert so
         any requests will be ignored except the destroy request.
       </description>
     </event>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy the zcosmic_workspace_handle_v1 object">
-        Destroys the zcosmic_workspace_handle_v1 object.
+      <description summary="destroy the zcosmic_workspace_handle_v2 object">
+        Destroys the zcosmic_workspace_handle_v2 object.
 
         This request should be called either when the client does not want to
         use the workspace object any more or after the remove event to finalize
@@ -365,7 +365,7 @@
 
     <event name="tiling_state" since="2">
       <description summary="indicates if tiling behavior is enabled for this workspace">
-        This event is emitted immediately after the zcosmic_workspace_handle_v1 is created
+        This event is emitted immediately after the zcosmic_workspace_handle_v2 is created
         and each time the workspace tiling state changes, either because of a
         compositor action or because of a request in this protocol.
       </description>


### PR DESCRIPTION
This PR introduces version 2 of the workspace protocol, which resolves the naming conflicts between events and requests. I’ve renamed the conflicting events to "destroyed," as this more accurately reflects their purpose. I’ve gone through the code and updated it accordingly, though there may be areas I missed.

Regarding the copyright header, I assume I need to add myself to provide the necessary permissions. However, I’ve held off on that for now since I haven’t rolled out a protocol before, so any guidance here would be helpful.

Marking this as a draft for now, as it's still open for feedback and further discussion.

fixes #36 