### PR TITLE
cctk: Add optional constructors

### DIFF
--- a/client-toolkit/src/screencopy.rs
+++ b/client-toolkit/src/screencopy.rs
@@ -88,7 +88,7 @@ pub struct ScreencopyState {
 }
 
 impl ScreencopyState {
-    pub fn new<D>(globals: &GlobalList, qh: &QueueHandle<D>) -> Self
+    pub fn try_new<D>(globals: &GlobalList, qh: &QueueHandle<D>) -> Option<Self>
     where
         D: 'static,
         D: Dispatch<zcosmic_screencopy_manager_v2::ZcosmicScreencopyManagerV2, ()>,
@@ -103,16 +103,34 @@ impl ScreencopyState {
         >,
     {
         // TODO bind
-        let screencopy_manager = globals.bind(qh, 1..=1, ()).unwrap(); // XXX
+        let screencopy_manager = globals.bind(qh, 1..=1, ()).ok()?;
         let output_source_manager = globals.bind(qh, 1..=1, ()).ok();
         let toplevel_source_manager = globals.bind(qh, 1..=1, ()).ok();
         let workspace_source_manager = globals.bind(qh, 1..=1, ()).ok();
-        Self {
+
+        Some(Self {
             screencopy_manager,
             output_source_manager,
             toplevel_source_manager,
             workspace_source_manager,
-        }
+        })
+    }
+
+    pub fn new<D>(globals: &GlobalList, qh: &QueueHandle<D>) -> Self
+    where
+        D: 'static,
+        D: Dispatch<zcosmic_screencopy_manager_v2::ZcosmicScreencopyManagerV2, ()>,
+        D: Dispatch<zcosmic_output_image_source_manager_v1::ZcosmicOutputImageSourceManagerV1, ()>,
+        D: Dispatch<
+            zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1,
+            (),
+        >,
+        D: Dispatch<
+            zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
+            (),
+        >,
+    {
+        Self::try_new(globals, qh).unwrap()
     }
 }
 

--- a/client-toolkit/src/toplevel_management.rs
+++ b/client-toolkit/src/toplevel_management.rs
@@ -7,15 +7,22 @@ pub struct ToplevelManagerState {
 }
 
 impl ToplevelManagerState {
-    pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
+    pub fn try_new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Option<Self>
     where
         D: Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, ()> + 'static,
     {
         let manager = registry
             .bind_one::<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, _, _>(qh, 1..=2, ())
-            .unwrap();
+            .ok()?;
 
-        Self { manager }
+        Some(Self { manager })
+    }
+
+    pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
+    where
+        D: Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, ()> + 'static,
+    {
+        Self::try_new(registry, qh).unwrap()
     }
 }
 


### PR DESCRIPTION
This allows cosmic-panel to still start up when cosmic-protocols are missing.