### PR TITLE
WIP `cosmic-image-capture-source-unstable-v1` for workspace capture

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,18 @@ pub mod image_source {
     }
 }
 
+pub mod image_capture_source {
+    //! Capture interface.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./unstable/cosmic-image-capture-source-unstable-v1.xml",
+            [wayland_protocols::ext::image_capture_source::v1, crate::workspace::v1]
+        );
+    }
+}
+
 pub mod screencopy {
     //! Capture interface.
 

--- a/unstable/cosmic-image-capture-source-unstable-v1.xml
+++ b/unstable/cosmic-image-capture-source-unstable-v1.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cosmic_image_cature_source_unstable_v1">
+  <copyright>
+    Copyright © 2025 System76
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="opaque image source objects">
+    This protocol serves as an intermediary between screen capturing protocols
+    and potential image sources such as outputs and toplevels.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="zcosmic_workspace_image_capture_source_manager_v1" version="1">
+    <description summary="image source manager for outputs">
+      A manager for creating image source objects for wl_output objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create source object for output">
+        Creates a source object for a workspaces. Images captured from this source
+        will show the same content as the workspace. Some elements may be omitted,
+        such as cursors and overlays that have been marked as transparent to
+        capturing.
+      </description>
+      <arg name="source" type="new_id" interface="ext_image_capture_source_v1"/>
+      <arg name="output" type="object" interface="zcosmic_workspace_handle_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the manager. This request may be sent at any time by the client
+        and objects created by the manager will remain valid after its
+        destruction.
+      </description>
+    </request>
+  </interface>
+</protocol>
+


### PR DESCRIPTION
This will be needed to replace cosmic-screencopy-v2 with ext-image-copy-capture-v1.

This could also use ext-workspace-v1 handles, but we'll need to add that in cosmic-comp first. That could also be contributed upstream. Though on other compositors, workspaces may be on multiple monitors, so either this needs a an `output` argument again, or it will capture a single image for multiple outputs. (Or there could be a way to do both, if that's desired.)