### PR TITLE
WIP workspace pin and move requests

### DIFF
--- a/client-toolkit/src/workspace.rs
+++ b/client-toolkit/src/workspace.rs
@@ -38,7 +38,7 @@ impl WorkspaceState {
     {
         Self {
             workspace_groups: Vec::new(),
-            manager: GlobalProxy::from(registry.bind_one(qh, 1..=2, GlobalData)),
+            manager: GlobalProxy::from(registry.bind_one(qh, 1..=3, GlobalData)),
         }
     }
 

--- a/unstable/cosmic-workspace-unstable-v1.xml
+++ b/unstable/cosmic-workspace-unstable-v1.xml
@@ -27,7 +27,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zcosmic_workspace_manager_v1" version="2">
+  <interface name="zcosmic_workspace_manager_v1" version="3">
     <description summary="list and control workspaces">
       Workspaces, also called virtual desktops, are groups of surfaces. A
       compositor with a concept of workspaces may only show some such groups of
@@ -285,6 +285,7 @@
           display such workspaces.
         </description>
       </entry>
+      <entry name="pinned" value="3" since="3" summary="the workspace is pinned"/>
     </enum>
 
     <enum name="zcosmic_workspace_capabilities_v1">
@@ -293,6 +294,8 @@
       <entry name="remove" value="3" summary="remove request is available"/>
       <entry name="rename" value="4" since="2" summary="rename request is available"/>
       <entry name="set_tiling_state" value="5" since="2" summary="set_tiling_state request is available"/>
+      <entry name="pin" value="6" since="3" summary="pin and unpin requests are available"/>
+      <entry name="move" value="7" since="3" summary="move_before and move_after requests are available"/>
     </enum>
 
     <event name="capabilities">
@@ -357,6 +360,32 @@
 
     <request name="remove">
       <description summary="remove the workspace">
+        Request that this workspace be removed.
+
+        There is no guarantee the workspace will be actually removed.
+      </description>
+    </request>
+
+    <request name="move_before">
+      <arg name="other_workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="axis", type="uint"/>
+    </request>
+
+    <request name="move_after">
+      <arg name="other_workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
+      <arg name="axis", type="uint"/>
+    </request>
+
+    <request name="pin", since="3">
+      <description summary="pin the workspace">
+        Request that this workspace be removed.
+
+        There is no guarantee the workspace will be actually removed.
+      </description>
+    </request>
+
+    <request name="unpin", since="3">
+      <description summary="pin the workspace">
         Request that this workspace be removed.
 
         There is no guarantee the workspace will be actually removed.


### PR DESCRIPTION
Workspace pinning, as needed for https://github.com/pop-os/cosmic-workspaces-epoch/issues/108.

That may not be very useful without a way to move workspaces. Particularly as pinned workspaces are moved automatically between outputs. So that is also added here.

Moving workspaces takes a `axis` argument, so it can handle two or more dimensional `coordinates`. The assumption (I still need to add docs here) is that the coordinates of workspaces on other dimensions would be unchanged. Though the upstream protocol is intentionally vague enough that this won't suit all uses. It could instead assume only one axis.

Now that ext-workspace-v1 exists, cosmic-workspace should probably be replaced with a v2 protocol that extends the upstream on, or turned into an extension protocol as was done with toplevel handles. If the latter isn't too awkward, that would help with migration of workspaces and screencopy.

Needs compositor and client implementation.