### PR TITLE
client-toolkit/toplevel-info: Work with only ext foreign toplevel 

### DIFF
--- a/client-toolkit/examples/toplevel-monitor.rs
+++ b/client-toolkit/examples/toplevel-monitor.rs
@@ -1,10 +1,10 @@
 use cosmic_client_toolkit::toplevel_info::{ToplevelInfoHandler, ToplevelInfoState};
-use cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1;
 use sctk::{
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
 };
 use wayland_client::{globals::registry_queue_init, protocol::wl_output, Connection, QueueHandle};
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1;
 
 struct AppData {
     output_state: OutputState,
@@ -60,7 +60,7 @@ impl ToplevelInfoHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
     ) {
         println!(
             "New toplevel: {:?}",
@@ -72,7 +72,7 @@ impl ToplevelInfoHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
     ) {
         println!(
             "Update toplevel: {:?}",
@@ -84,7 +84,7 @@ impl ToplevelInfoHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
     ) {
         println!(
             "Closed toplevel: {:?}",

--- a/client-toolkit/examples/toplevel-monitor.rs
+++ b/client-toolkit/examples/toplevel-monitor.rs
@@ -30,7 +30,7 @@ impl OutputHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
+        _output: wl_output::WlOutput,
     ) {
     }
 
@@ -46,7 +46,7 @@ impl OutputHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
+        _output: wl_output::WlOutput,
     ) {
     }
 }
@@ -92,7 +92,7 @@ impl ToplevelInfoHandler for AppData {
         );
     }
 
-    fn info_done(&mut self, conn: &Connection, qh: &QueueHandle<Self>) {
+    fn info_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
         println!("Info done");
     }
 }

--- a/client-toolkit/examples/workspaces.rs
+++ b/client-toolkit/examples/workspaces.rs
@@ -29,7 +29,7 @@ impl OutputHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
+        _output: wl_output::WlOutput,
     ) {
     }
 
@@ -45,7 +45,7 @@ impl OutputHandler for AppData {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
+        _output: wl_output::WlOutput,
     ) {
     }
 }

--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -131,17 +131,10 @@ impl ToplevelInfoState {
             .as_ref()
     }
 
-    pub fn toplevels(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
-            Option<&ToplevelInfo>,
-        ),
-    > {
+    pub fn toplevels(&self) -> impl Iterator<Item = &ToplevelInfo> {
         self.toplevels
             .iter()
-            .map(|data| (data.foreign_toplevel(), data.current_info.as_ref()))
+            .filter_map(|data| data.current_info.as_ref())
     }
 }
 


### PR DESCRIPTION
Supporting both cosmic toplevel info version 1 and foreign toplevel list (with cosmic toplevel info) seems awkward. So this initially make the cosmic-protocol mandatory and the ext protocol optional (without breaking the API). But now that Cosmic has supported this for a while, lets drop client-side support for the old version, and add support for other compositors implementing `ext-foreign-toplevel-list-v1`.

I still need to update users of the library for this. Probably after https://github.com/pop-os/cosmic-protocols/pull/46. Looks like `ext_foreign_toplevel_image_capture_source_manager_v1`  isn't currently implemented by Sway? So this doesn't yet capture windows on Sway.