### PR TITLE
client-toolkit: Remove optional `smithay` feature

### DIFF
--- a/client-toolkit/Cargo.toml
+++ b/client-toolkit/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 cosmic-protocols = { path = "../" }
 sctk = { package = "smithay-client-toolkit", version = "0.19.1" }
 wayland-client = { version = "0.31.1" }
-smithay = { git = "https://github.com/Smithay/smithay", rev = "c35bc3e", default-features = false, features = ["backend_egl", "renderer_gl", "renderer_multi"], optional = true }
 libc = "0.2.153"
 wayland-protocols = { version = "0.32.4", features = ["client", "staging"] }
 


### PR DESCRIPTION
No longer used after removing `export_dmabuf`.