### PR TITLE
Cosmic workspace v2, based on `ext-workspace-v1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 wayland-scanner = "0.31.0"
 wayland-backend = "0.3.1"
-wayland-protocols = { version = "0.32.1", features = ["staging"] }
+wayland-protocols = { version = "0.32.6", features = ["staging"] }
 wayland-protocols-wlr = "0.3.1"
 wayland-client = { version = "0.31.1", optional = true }
 wayland-server = { version = "0.31.0", optional = true }

--- a/client-toolkit/Cargo.toml
+++ b/client-toolkit/Cargo.toml
@@ -9,6 +9,7 @@ sctk = { package = "smithay-client-toolkit", version = "0.19.1" }
 wayland-client = { version = "0.31.1" }
 libc = "0.2.153"
 wayland-protocols = { version = "0.32.4", features = ["client", "staging"] }
+bitflags = "2.8.0"
 
 [dev-dependencies]
 futures = "0.3.24"

--- a/client-toolkit/examples/workspaces.rs
+++ b/client-toolkit/examples/workspaces.rs
@@ -72,7 +72,6 @@ impl WorkspaceHandler for AppData {
             let mut workspaces = self
                 .workspace_state
                 .workspaces()
-                .iter()
                 .filter(|w| group.workspaces.contains(&w.handle))
                 .collect::<Vec<_>>();
             workspaces.sort_by(|w1, w2| w1.coordinates.cmp(&w2.coordinates));

--- a/client-toolkit/examples/workspaces.rs
+++ b/client-toolkit/examples/workspaces.rs
@@ -69,12 +69,20 @@ impl WorkspaceHandler for AppData {
                 "Group: outputs: {:?}, capabilities: {:?}",
                 output_names, group.capabilities,
             );
-            for workspace in &group.workspaces {
+            let mut workspaces = self
+                .workspace_state
+                .workspaces()
+                .iter()
+                .filter(|w| group.workspaces.contains(&w.handle))
+                .collect::<Vec<_>>();
+            workspaces.sort_by(|w1, w2| w1.coordinates.cmp(&w2.coordinates));
+            for workspace in workspaces {
                 println!(
-                    "  Workspace: name: {}, coordinates: {:?}, capabilties: {:?}, state: {:?}, tiling: {:?}",
+                    "  Workspace: name: {}, coordinates: {:?}, capabilties: {:?}, cosmic capabilities: {:?}, state: {:?}, tiling: {:?}",
                     &workspace.name,
                     &workspace.coordinates,
                     &workspace.capabilities,
+                    &workspace.cosmic_capabilities,
                     &workspace.state,
                     &workspace.tiling,
                 );

--- a/client-toolkit/src/screencopy/capture_source.rs
+++ b/client-toolkit/src/screencopy/capture_source.rs
@@ -1,7 +1,4 @@
-use cosmic_protocols::{
-    image_source::v1::client::zcosmic_image_source_v1,
-    workspace::v1::client::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
-};
+use cosmic_protocols::image_source::v1::client::zcosmic_image_source_v1;
 use std::{error::Error, fmt};
 use wayland_client::{protocol::wl_output, Dispatch, Proxy, QueueHandle};
 use wayland_protocols::ext::{
@@ -29,7 +26,6 @@ pub enum CaptureSourceKind {
     Output,
     Toplevel,
     Workspace,
-    CosmicWorkspace,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -37,7 +33,6 @@ pub enum CaptureSource {
     Output(wl_output::WlOutput),
     Toplevel(ExtForeignToplevelHandleV1),
     Workspace(ExtWorkspaceHandleV1),
-    CosmicWorkspace(ZcosmicWorkspaceHandleV1),
 }
 
 impl CaptureSource {
@@ -46,7 +41,6 @@ impl CaptureSource {
             Self::Output(_) => CaptureSourceKind::Output,
             Self::Toplevel(_) => CaptureSourceKind::Toplevel,
             Self::Workspace(_) => CaptureSourceKind::Workspace,
-            Self::CosmicWorkspace(_) => CaptureSourceKind::CosmicWorkspace,
         }
     }
 
@@ -83,7 +77,6 @@ impl CaptureSource {
                         ));
                     }
                 }
-                CaptureSource::CosmicWorkspace(_) => {}
             }
         }
         if let Some(cosmic_screencopy) = &capturer.0.cosmic_screencopy {
@@ -111,13 +104,6 @@ impl CaptureSource {
                 }
                 CaptureSource::Workspace(workspace) => {
                     if let Some(manager) = &cosmic_screencopy.ext_workspace_source_manager {
-                        return Ok(WlCaptureSource::Cosmic(
-                            manager.create_source(workspace, qh, GlobalData),
-                        ));
-                    }
-                }
-                CaptureSource::CosmicWorkspace(workspace) => {
-                    if let Some(manager) = &cosmic_screencopy.workspace_source_manager {
                         return Ok(WlCaptureSource::Cosmic(
                             manager.create_source(workspace, qh, GlobalData),
                         ));

--- a/client-toolkit/src/screencopy/dispatch/cosmic.rs
+++ b/client-toolkit/src/screencopy/dispatch/cosmic.rs
@@ -2,7 +2,6 @@ use cosmic_protocols::{
     image_source::v1::client::{
         zcosmic_ext_workspace_image_source_manager_v1, zcosmic_image_source_v1,
         zcosmic_output_image_source_manager_v1, zcosmic_toplevel_image_source_manager_v1,
-        zcosmic_workspace_image_source_manager_v1,
     },
     screencopy::v2::client::{
         zcosmic_screencopy_frame_v2, zcosmic_screencopy_manager_v2, zcosmic_screencopy_session_v2,
@@ -239,30 +238,6 @@ where
 
 impl<D>
     Dispatch<
-        zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
-        GlobalData,
-        D,
-    > for ScreencopyState
-where
-    D: Dispatch<
-            zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
-            GlobalData,
-        > + ScreencopyHandler,
-{
-    fn event(
-        _app_data: &mut D,
-        _source: &zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
-        _event: zcosmic_workspace_image_source_manager_v1::Event,
-        _udata: &GlobalData,
-        _conn: &Connection,
-        _qh: &QueueHandle<D>,
-    ) {
-        unreachable!()
-    }
-}
-
-impl<D>
-    Dispatch<
         zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
         GlobalData,
         D,
@@ -297,9 +272,6 @@ macro_rules! delegate_cosmic_screencopy {
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::cosmic_protocols::image_source::v1::client::zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1: $crate::GlobalData
-        ] => $crate::screencopy::ScreencopyState);
-        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::image_source::v1::client::zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1: $crate::GlobalData
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::cosmic_protocols::image_source::v1::client::zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1: $crate::GlobalData

--- a/client-toolkit/src/screencopy/dispatch/cosmic.rs
+++ b/client-toolkit/src/screencopy/dispatch/cosmic.rs
@@ -1,7 +1,8 @@
 use cosmic_protocols::{
     image_source::v1::client::{
-        zcosmic_image_source_v1, zcosmic_output_image_source_manager_v1,
-        zcosmic_toplevel_image_source_manager_v1, zcosmic_workspace_image_source_manager_v1,
+        zcosmic_ext_workspace_image_source_manager_v1, zcosmic_image_source_v1,
+        zcosmic_output_image_source_manager_v1, zcosmic_toplevel_image_source_manager_v1,
+        zcosmic_workspace_image_source_manager_v1,
     },
     screencopy::v2::client::{
         zcosmic_screencopy_frame_v2, zcosmic_screencopy_manager_v2, zcosmic_screencopy_session_v2,
@@ -260,6 +261,30 @@ where
     }
 }
 
+impl<D>
+    Dispatch<
+        zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
+        GlobalData,
+        D,
+    > for ScreencopyState
+where
+    D: Dispatch<
+            zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
+            GlobalData,
+        > + ScreencopyHandler,
+{
+    fn event(
+        _app_data: &mut D,
+        _source: &zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
+        _event: zcosmic_ext_workspace_image_source_manager_v1::Event,
+        _udata: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
 #[macro_export]
 macro_rules! delegate_cosmic_screencopy {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
@@ -275,6 +300,9 @@ macro_rules! delegate_cosmic_screencopy {
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::cosmic_protocols::image_source::v1::client::zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::image_source::v1::client::zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1: $crate::GlobalData
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::cosmic_protocols::image_source::v1::client::zcosmic_image_source_v1::ZcosmicImageSourceV1: $crate::GlobalData

--- a/client-toolkit/src/screencopy/dispatch/ext.rs
+++ b/client-toolkit/src/screencopy/dispatch/ext.rs
@@ -1,3 +1,4 @@
+use cosmic_protocols::image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1;
 use std::time::Duration;
 use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
 use wayland_protocols::ext::{
@@ -236,6 +237,30 @@ where
     }
 }
 
+impl<D>
+    Dispatch<
+        zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1,
+        GlobalData,
+        D,
+    > for ScreencopyState
+where
+    D: Dispatch<
+            zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1,
+            GlobalData,
+        > + ScreencopyHandler,
+{
+    fn event(
+        _app_data: &mut D,
+        _source: &zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1,
+        _event: zcosmic_workspace_image_capture_source_manager_v1::Event,
+        _udata: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
 #[macro_export]
 macro_rules! delegate_ext_image_capture {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
@@ -251,6 +276,9 @@ macro_rules! delegate_ext_image_capture {
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::wayland_protocols::ext::image_capture_source::v1::client::ext_image_capture_source_v1::ExtImageCaptureSourceV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1: $crate::GlobalData
         ] => $crate::screencopy::ScreencopyState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1: $crate::GlobalData

--- a/client-toolkit/src/screencopy/mod.rs
+++ b/client-toolkit/src/screencopy/mod.rs
@@ -1,9 +1,11 @@
 // TODO add cursor session support
 
 use cosmic_protocols::{
+    image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1,
     image_source::v1::client::{
-        zcosmic_image_source_v1, zcosmic_output_image_source_manager_v1,
-        zcosmic_toplevel_image_source_manager_v1, zcosmic_workspace_image_source_manager_v1,
+        zcosmic_ext_workspace_image_source_manager_v1, zcosmic_image_source_v1,
+        zcosmic_output_image_source_manager_v1, zcosmic_toplevel_image_source_manager_v1,
+        zcosmic_workspace_image_source_manager_v1,
     },
     screencopy::v2::client::{
         zcosmic_screencopy_frame_v2, zcosmic_screencopy_manager_v2, zcosmic_screencopy_session_v2,
@@ -85,6 +87,9 @@ struct CosmicScreencopy {
         Option<zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1>,
     workspace_source_manager:
         Option<zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1>,
+    ext_workspace_source_manager: Option<
+        zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
+    >,
 }
 
 impl CosmicScreencopy {
@@ -104,16 +109,22 @@ impl CosmicScreencopy {
             zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
             GlobalData,
         >,
+        D: Dispatch<
+            zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
+            GlobalData,
+        >,
     {
         let screencopy_manager = globals.bind(qh, 1..=1, GlobalData).ok()?;
         let output_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         let toplevel_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         let workspace_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
+        let ext_workspace_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         Some(Self {
             screencopy_manager,
             output_source_manager,
             toplevel_source_manager,
             workspace_source_manager,
+            ext_workspace_source_manager,
         })
     }
 }
@@ -123,6 +134,7 @@ struct ImageCopyCapture {
     image_copy_capture_manager: ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1,
     output_source_manager: Option<ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1>,
     foreign_toplevel_source_manager: Option<ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1>,
+    workspace_source_manager: Option<zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1>,
 }
 
 impl ImageCopyCapture {
@@ -132,14 +144,17 @@ impl ImageCopyCapture {
         D: Dispatch<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, GlobalData>,
         D: Dispatch<ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1, GlobalData>,
         D: Dispatch<ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1, GlobalData>,
+        D: Dispatch<zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1, GlobalData>,
     {
         let image_copy_capture_manager = globals.bind(qh, 1..=1, GlobalData).ok()?;
         let output_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         let foreign_toplevel_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
+        let workspace_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         Some(Self {
             image_copy_capture_manager,
             output_source_manager,
             foreign_toplevel_source_manager,
+            workspace_source_manager,
         })
     }
 }
@@ -163,6 +178,9 @@ impl Drop for CapturerInner {
             if let Some(manager) = &cosmic_screencopy.workspace_source_manager {
                 manager.destroy();
             }
+            if let Some(manager) = &cosmic_screencopy.ext_workspace_source_manager {
+                manager.destroy();
+            }
         }
         if let Some(image_copy_capture) = &self.image_copy_capture {
             image_copy_capture.image_copy_capture_manager.destroy();
@@ -170,6 +188,9 @@ impl Drop for CapturerInner {
                 manager.destroy();
             }
             if let Some(manager) = &image_copy_capture.foreign_toplevel_source_manager {
+                manager.destroy();
+            }
+            if let Some(manager) = &image_copy_capture.workspace_source_manager {
                 manager.destroy();
             }
         }
@@ -367,6 +388,8 @@ impl ScreencopyState {
         D: Dispatch<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, GlobalData>,
         D: Dispatch<ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1, GlobalData>,
         D: Dispatch<ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1, GlobalData>,
+        D: Dispatch<zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1, GlobalData>,
+        D: Dispatch<zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1, GlobalData>,
     {
         let capturer = Capturer(Arc::new(CapturerInner {
             cosmic_screencopy: CosmicScreencopy::new(globals, qh),

--- a/client-toolkit/src/screencopy/mod.rs
+++ b/client-toolkit/src/screencopy/mod.rs
@@ -5,7 +5,6 @@ use cosmic_protocols::{
     image_source::v1::client::{
         zcosmic_ext_workspace_image_source_manager_v1, zcosmic_image_source_v1,
         zcosmic_output_image_source_manager_v1, zcosmic_toplevel_image_source_manager_v1,
-        zcosmic_workspace_image_source_manager_v1,
     },
     screencopy::v2::client::{
         zcosmic_screencopy_frame_v2, zcosmic_screencopy_manager_v2, zcosmic_screencopy_session_v2,
@@ -85,8 +84,6 @@ struct CosmicScreencopy {
         Option<zcosmic_output_image_source_manager_v1::ZcosmicOutputImageSourceManagerV1>,
     toplevel_source_manager:
         Option<zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1>,
-    workspace_source_manager:
-        Option<zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1>,
     ext_workspace_source_manager: Option<
         zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
     >,
@@ -106,10 +103,6 @@ impl CosmicScreencopy {
             GlobalData,
         >,
         D: Dispatch<
-            zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
-            GlobalData,
-        >,
-        D: Dispatch<
             zcosmic_ext_workspace_image_source_manager_v1::ZcosmicExtWorkspaceImageSourceManagerV1,
             GlobalData,
         >,
@@ -117,13 +110,11 @@ impl CosmicScreencopy {
         let screencopy_manager = globals.bind(qh, 1..=1, GlobalData).ok()?;
         let output_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         let toplevel_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
-        let workspace_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         let ext_workspace_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
         Some(Self {
             screencopy_manager,
             output_source_manager,
             toplevel_source_manager,
-            workspace_source_manager,
             ext_workspace_source_manager,
         })
     }
@@ -173,9 +164,6 @@ impl Drop for CapturerInner {
                 manager.destroy();
             }
             if let Some(manager) = &cosmic_screencopy.toplevel_source_manager {
-                manager.destroy();
-            }
-            if let Some(manager) = &cosmic_screencopy.workspace_source_manager {
                 manager.destroy();
             }
             if let Some(manager) = &cosmic_screencopy.ext_workspace_source_manager {
@@ -379,10 +367,6 @@ impl ScreencopyState {
         >,
         D: Dispatch<
             zcosmic_toplevel_image_source_manager_v1::ZcosmicToplevelImageSourceManagerV1,
-            GlobalData,
-        >,
-        D: Dispatch<
-            zcosmic_workspace_image_source_manager_v1::ZcosmicWorkspaceImageSourceManagerV1,
             GlobalData,
         >,
         D: Dispatch<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, GlobalData>,

--- a/client-toolkit/src/toplevel_management.rs
+++ b/client-toolkit/src/toplevel_management.rs
@@ -16,7 +16,7 @@ impl ToplevelManagerState {
         let manager = registry
             .bind_one::<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, _, _>(
                 qh,
-                1..=2,
+                1..=4,
                 GlobalData,
             )
             .ok()?;

--- a/client-toolkit/src/workspace.rs
+++ b/client-toolkit/src/workspace.rs
@@ -1,55 +1,70 @@
-use cosmic_protocols::workspace::v1::client::{
-    zcosmic_workspace_group_handle_v1, zcosmic_workspace_handle_v1, zcosmic_workspace_manager_v1,
+use cosmic_protocols::workspace::v2::client::{
+    zcosmic_workspace_handle_v2, zcosmic_workspace_manager_v2,
 };
 use sctk::registry::{GlobalProxy, RegistryState};
+use std::collections::HashSet;
 use wayland_client::{protocol::wl_output, Connection, Dispatch, QueueHandle, WEnum};
+use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1, ext_workspace_handle_v1, ext_workspace_manager_v1,
+};
 
 use crate::GlobalData;
 
 #[derive(Clone, Debug)]
 pub struct WorkspaceGroup {
-    pub handle: zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
-    pub capabilities:
-        Vec<WEnum<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupCapabilitiesV1>>,
+    pub handle: ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    pub capabilities: WEnum<ext_workspace_group_handle_v1::GroupCapabilities>,
     pub outputs: Vec<wl_output::WlOutput>,
-    pub workspaces: Vec<Workspace>,
+    pub workspaces: HashSet<ext_workspace_handle_v1::ExtWorkspaceHandleV1>,
 }
 
 #[derive(Clone, Debug)]
 pub struct Workspace {
-    pub handle: zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
+    pub handle: ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    pub cosmic_handle: Option<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2>,
     pub name: String,
     pub coordinates: Vec<u32>,
-    pub state: Vec<WEnum<zcosmic_workspace_handle_v1::State>>,
-    pub capabilities: Vec<WEnum<zcosmic_workspace_handle_v1::ZcosmicWorkspaceCapabilitiesV1>>,
-    pub tiling: Option<WEnum<zcosmic_workspace_handle_v1::TilingState>>,
+    pub state: WEnum<ext_workspace_handle_v1::State>,
+    pub capabilities: WEnum<ext_workspace_handle_v1::WorkspaceCapabilities>,
+    pub cosmic_capabilities: WEnum<zcosmic_workspace_handle_v2::WorkspaceCapabilities>,
+    pub tiling: Option<WEnum<zcosmic_workspace_handle_v2::TilingState>>,
 }
 
 #[derive(Debug)]
 pub struct WorkspaceState {
     workspace_groups: Vec<WorkspaceGroup>,
-    manager: GlobalProxy<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1>,
+    workspaces: Vec<Workspace>,
+    manager: GlobalProxy<ext_workspace_manager_v1::ExtWorkspaceManagerV1>,
+    cosmic_manager: GlobalProxy<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2>,
 }
 
 impl WorkspaceState {
     pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
     where
-        D: Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, GlobalData> + 'static,
+        D: Dispatch<ext_workspace_manager_v1::ExtWorkspaceManagerV1, GlobalData>
+            + Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, GlobalData>
+            + 'static,
     {
         Self {
             workspace_groups: Vec::new(),
-            manager: GlobalProxy::from(registry.bind_one(qh, 1..=2, GlobalData)),
+            workspaces: Vec::new(),
+            manager: GlobalProxy::from(registry.bind_one(qh, 1..=1, GlobalData)),
+            cosmic_manager: GlobalProxy::from(registry.bind_one(qh, 1..=1, GlobalData)),
         }
     }
 
     pub fn workspace_manager(
         &self,
-    ) -> &GlobalProxy<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1> {
+    ) -> &GlobalProxy<ext_workspace_manager_v1::ExtWorkspaceManagerV1> {
         &self.manager
     }
 
     pub fn workspace_groups(&self) -> &[WorkspaceGroup] {
         &self.workspace_groups
+    }
+
+    pub fn workspaces(&self) -> &[Workspace] {
+        &self.workspaces
     }
 }
 
@@ -60,59 +75,88 @@ pub trait WorkspaceHandler {
     fn done(&mut self);
 }
 
-impl<D> Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, GlobalData, D>
-    for WorkspaceState
+impl<D> Dispatch<ext_workspace_manager_v1::ExtWorkspaceManagerV1, GlobalData, D> for WorkspaceState
 where
-    D: Dispatch<zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, GlobalData>
-        + Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, GlobalData>
+    D: Dispatch<ext_workspace_manager_v1::ExtWorkspaceManagerV1, GlobalData>
+        + Dispatch<ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData>
+        + Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData>
+        + Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, GlobalData>
         + WorkspaceHandler
         + 'static,
 {
     fn event(
         state: &mut D,
-        _: &zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1,
-        event: zcosmic_workspace_manager_v1::Event,
+        _: &ext_workspace_manager_v1::ExtWorkspaceManagerV1,
+        event: ext_workspace_manager_v1::Event,
         _: &GlobalData,
         _: &Connection,
-        _: &QueueHandle<D>,
+        qh: &QueueHandle<D>,
     ) {
         match event {
-            zcosmic_workspace_manager_v1::Event::WorkspaceGroup { workspace_group } => {
+            ext_workspace_manager_v1::Event::WorkspaceGroup { workspace_group } => {
                 state
                     .workspace_state()
                     .workspace_groups
                     .push(WorkspaceGroup {
                         handle: workspace_group,
-                        capabilities: Vec::new(),
+                        capabilities: WEnum::Value(
+                            ext_workspace_group_handle_v1::GroupCapabilities::empty(),
+                        ),
                         outputs: Vec::new(),
-                        workspaces: Vec::new(),
+                        workspaces: HashSet::new(),
                     });
             }
-            zcosmic_workspace_manager_v1::Event::Done => {
+            ext_workspace_manager_v1::Event::Workspace { workspace } => {
+                let cosmic_handle =
+                    state
+                        .workspace_state()
+                        .cosmic_manager
+                        .get()
+                        .ok()
+                        .map(|cosmic_manager| {
+                            cosmic_manager.get_cosmic_workspace(&workspace, qh, GlobalData)
+                        });
+                state.workspace_state().workspaces.push(Workspace {
+                    handle: workspace,
+                    cosmic_handle,
+                    name: String::new(),
+                    coordinates: Vec::new(),
+                    state: WEnum::Value(ext_workspace_handle_v1::State::empty()),
+                    capabilities: WEnum::Value(
+                        ext_workspace_handle_v1::WorkspaceCapabilities::empty(),
+                    ),
+                    cosmic_capabilities: WEnum::Value(
+                        zcosmic_workspace_handle_v2::WorkspaceCapabilities::empty(),
+                    ),
+                    tiling: None,
+                });
+            }
+            ext_workspace_manager_v1::Event::Done => {
                 state.done();
             }
-            zcosmic_workspace_manager_v1::Event::Finished => {}
+            ext_workspace_manager_v1::Event::Finished => {}
             _ => unreachable!(),
         }
     }
 
-    wayland_client::event_created_child!(D, zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1, [
-        zcosmic_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE => (zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, GlobalData)
+    wayland_client::event_created_child!(D, ext_workspace_manager_v1::ExtWorkspaceManagerV1, [
+        ext_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE => (ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData),
+        ext_workspace_manager_v1::EVT_WORKSPACE_OPCODE => (ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData)
     ]);
 }
 
-impl<D> Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, GlobalData, D>
+impl<D> Dispatch<ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData, D>
     for WorkspaceState
 where
-    D: Dispatch<zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, GlobalData>
-        + Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, GlobalData>
+    D: Dispatch<ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData>
+        + Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData>
         + WorkspaceHandler
         + 'static,
 {
     fn event(
         state: &mut D,
-        handle: &zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1,
-        event: zcosmic_workspace_group_handle_v1::Event,
+        handle: &ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+        event: ext_workspace_group_handle_v1::Event,
         _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
@@ -124,31 +168,24 @@ where
             .find(|group| &group.handle == handle)
             .unwrap();
         match event {
-            zcosmic_workspace_group_handle_v1::Event::Capabilities { capabilities } => {
-                group.capabilities = capabilities
-                    .chunks(4)
-                    .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
-                    .collect();
+            ext_workspace_group_handle_v1::Event::Capabilities { capabilities } => {
+                group.capabilities = capabilities;
             }
-            zcosmic_workspace_group_handle_v1::Event::OutputEnter { output } => {
+            ext_workspace_group_handle_v1::Event::OutputEnter { output } => {
                 group.outputs.push(output);
             }
-            zcosmic_workspace_group_handle_v1::Event::OutputLeave { output } => {
+            ext_workspace_group_handle_v1::Event::OutputLeave { output } => {
                 if let Some(idx) = group.outputs.iter().position(|x| x == &output) {
                     group.outputs.remove(idx);
                 }
             }
-            zcosmic_workspace_group_handle_v1::Event::Workspace { workspace } => {
-                group.workspaces.push(Workspace {
-                    handle: workspace,
-                    name: String::new(),
-                    coordinates: Vec::new(),
-                    state: Vec::new(),
-                    capabilities: Vec::new(),
-                    tiling: None,
-                });
+            ext_workspace_group_handle_v1::Event::WorkspaceEnter { workspace } => {
+                group.workspaces.insert(workspace);
             }
-            zcosmic_workspace_group_handle_v1::Event::Remove => {
+            ext_workspace_group_handle_v1::Event::WorkspaceLeave { workspace } => {
+                group.workspaces.remove(&workspace);
+            }
+            ext_workspace_group_handle_v1::Event::Removed => {
                 if let Some(idx) = state
                     .workspace_state()
                     .workspace_groups
@@ -161,73 +198,106 @@ where
             _ => unreachable!(),
         }
     }
-
-    wayland_client::event_created_child!(D, zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1, [
-        zcosmic_workspace_group_handle_v1::EVT_WORKSPACE_OPCODE => (zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, GlobalData)
-    ]);
 }
 
-impl<D> Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, GlobalData, D>
-    for WorkspaceState
+impl<D> Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData, D> for WorkspaceState
 where
-    D: Dispatch<zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1, GlobalData>
-        + WorkspaceHandler,
+    D: Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData> + WorkspaceHandler,
 {
     fn event(
         state: &mut D,
-        handle: &zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1,
-        event: zcosmic_workspace_handle_v1::Event,
+        handle: &ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+        event: ext_workspace_handle_v1::Event,
         _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
         let workspace = state
             .workspace_state()
-            .workspace_groups
+            .workspaces
             .iter_mut()
-            .find_map(|group| group.workspaces.iter_mut().find(|w| &w.handle == handle))
+            .find(|w| &w.handle == handle)
             .unwrap();
         match event {
-            zcosmic_workspace_handle_v1::Event::Name { name } => {
+            ext_workspace_handle_v1::Event::Name { name } => {
                 workspace.name = name;
             }
-            zcosmic_workspace_handle_v1::Event::Coordinates { coordinates } => {
+            ext_workspace_handle_v1::Event::Coordinates { coordinates } => {
                 workspace.coordinates = coordinates
                     .chunks(4)
                     .map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
                     .collect();
-                // Keep `.workspaces` sorted by `coordinates`
-                let group = state
-                    .workspace_state()
-                    .workspace_groups
-                    .iter_mut()
-                    .find(|group| group.workspaces.iter().any(|w| &w.handle == handle))
-                    .unwrap();
-                group
-                    .workspaces
-                    .sort_by(|w1, w2| w1.coordinates.cmp(&w2.coordinates));
             }
-            zcosmic_workspace_handle_v1::Event::State { state } => {
-                workspace.state = state
-                    .chunks(4)
-                    .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
-                    .collect();
+            ext_workspace_handle_v1::Event::State { state } => {
+                workspace.state = state;
             }
-            zcosmic_workspace_handle_v1::Event::Capabilities { capabilities } => {
-                workspace.capabilities = capabilities
-                    .chunks(4)
-                    .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
-                    .collect();
+            ext_workspace_handle_v1::Event::Capabilities { capabilities } => {
+                workspace.capabilities = capabilities;
             }
-            zcosmic_workspace_handle_v1::Event::TilingState { state } => {
-                workspace.tiling = Some(state);
-            }
-            zcosmic_workspace_handle_v1::Event::Remove => {
+            ext_workspace_handle_v1::Event::Removed => {
                 for group in state.workspace_state().workspace_groups.iter_mut() {
-                    if let Some(idx) = group.workspaces.iter().position(|w| &w.handle == handle) {
-                        group.workspaces.remove(idx);
-                    }
+                    group.workspaces.remove(handle);
                 }
+                if let Some(idx) = state
+                    .workspace_state()
+                    .workspaces
+                    .iter()
+                    .position(|w| &w.handle == handle)
+                {
+                    state.workspace_state().workspaces.remove(idx);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, GlobalData, D>
+    for WorkspaceState
+where
+    D: Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, GlobalData>
+        + WorkspaceHandler
+        + 'static,
+{
+    fn event(
+        _: &mut D,
+        _: &zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2,
+        _: zcosmic_workspace_manager_v2::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D> Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, GlobalData, D>
+    for WorkspaceState
+where
+    D: Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, GlobalData>
+        + WorkspaceHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        handle: &zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2,
+        event: zcosmic_workspace_handle_v2::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        let workspace = state
+            .workspace_state()
+            .workspaces
+            .iter_mut()
+            .find(|w| w.cosmic_handle.as_ref() == Some(&handle))
+            .unwrap();
+        match event {
+            zcosmic_workspace_handle_v2::Event::Capabilities { capabilities } => {
+                workspace.cosmic_capabilities = capabilities;
+            }
+            zcosmic_workspace_handle_v2::Event::TilingState { state } => {
+                workspace.tiling = Some(state);
             }
             _ => unreachable!(),
         }
@@ -238,13 +308,20 @@ where
 macro_rules! delegate_workspace {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::workspace::v1::client::zcosmic_workspace_manager_v1::ZcosmicWorkspaceManagerV1: $crate::GlobalData
+            $crate::wayland_protocols::ext::workspace::v1::client::ext_workspace_manager_v1::ExtWorkspaceManagerV1: $crate::GlobalData
         ] => $crate::workspace::WorkspaceState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::workspace::v1::client::zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1: $crate::GlobalData
+            $crate::wayland_protocols::ext::workspace::v1::client::ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1: $crate::GlobalData
         ] => $crate::workspace::WorkspaceState);
         $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::cosmic_protocols::workspace::v1::client::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1: $crate::GlobalData
+            $crate::wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2: $crate::GlobalData
         ] => $crate::workspace::WorkspaceState);
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,4 +135,13 @@ pub mod workspace {
             []
         );
     }
+
+
+    #[allow(missing_docs)]
+    pub mod v2 {
+        wayland_protocol!(
+            "./unstable/cosmic-workspace-unstable-v2.xml",
+            [wayland_protocols::ext::workspace::v1]
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,18 @@ pub mod atspi {
     }
 }
 
+pub mod image_capture_source {
+    //! Capture source interface extending `ext-image-capture-source-v1`.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./unstable/cosmic-image-capture-source-unstable-v1.xml",
+            [wayland_protocols::ext::image_capture_source::v1, wayland_protocols::ext::workspace::v1]
+        );
+    }
+}
+
 pub mod image_source {
     //! Capture interface.
 
@@ -48,7 +60,7 @@ pub mod image_source {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-image-source-unstable-v1.xml",
-            [crate::workspace::v1, crate::toplevel_info::v1]
+            [crate::workspace::v1, crate::toplevel_info::v1, wayland_protocols::ext::workspace::v1]
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub mod toplevel_info {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-toplevel-info-unstable-v1.xml",
-            [crate::workspace::v1, wayland_protocols::ext::foreign_toplevel_list::v1]
+            [crate::workspace::v1, wayland_protocols::ext::foreign_toplevel_list::v1, wayland_protocols::ext::workspace::v1]
         );
     }
 }
@@ -108,7 +108,7 @@ pub mod toplevel_management {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-toplevel-management-unstable-v1.xml",
-            [crate::toplevel_info::v1, crate::workspace::v1]
+            [crate::toplevel_info::v1, crate::workspace::v1, wayland_protocols::ext::workspace::v1]
         );
     }
 }

--- a/unstable/cosmic-image-capture-source-unstable-v1.xml
+++ b/unstable/cosmic-image-capture-source-unstable-v1.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cosmic_image_source_unstable_v1">
+  <copyright>
+    Copyright © 2025 System76
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="cosmic image capture sources">
+    This protocols `extends ext-image-capture-source-v1` with additional capture
+    sources.
+  </description>
+
+  <interface name="zcosmic_workspace_image_capture_source_manager_v1" version="1">
+    <description summary="image source manager for outputs">
+      A manager for creating image source objects for wl_output objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create source object for output">
+        Creates a source object for a workspaces. Images captured from this source
+        will show the same content as the workspace. Some elements may be omitted,
+        such as cursors and overlays that have been marked as transparent to
+        capturing.
+      </description>
+      <arg name="source" type="new_id" interface="ext_image_capture_source_v1"/>
+      <arg name="output" type="object" interface="ext_workspace_handle_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the manager. This request may be sent at any time by the client
+        and objects created by the manager will remain valid after its
+        destruction.
+      </description>
+    </request>
+  </interface>
+</protocol>
+

--- a/unstable/cosmic-image-source-unstable-v1.xml
+++ b/unstable/cosmic-image-source-unstable-v1.xml
@@ -107,6 +107,31 @@
     </request>
   </interface>
 
+  <interface name="zcosmic_ext_workspace_image_source_manager_v1" version="1">
+    <description summary="image source manager for outputs">
+      A manager for creating image source objects for wl_output objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create source object for output">
+        Creates a source object for a workspaces. Images captured from this source
+        will show the same content as the workspace. Some elements may be omitted,
+        such as cursors and overlays that have been marked as transparent to
+        capturing.
+      </description>
+      <arg name="source" type="new_id" interface="zcosmic_image_source_v1"/>
+      <arg name="output" type="object" interface="ext_workspace_handle_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the manager. This request may be sent at any time by the client
+        and objects created by the manager will remain valid after its
+        destruction.
+      </description>
+    </request>
+  </interface>
+
   <interface name="zcosmic_toplevel_image_source_manager_v1" version="1">
     <description summary="image source manager for toplevels">
       A manager for creating image source objects for

--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -27,7 +27,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zcosmic_toplevel_info_v1" version="2">
+  <interface name="zcosmic_toplevel_info_v1" version="3">
     <description summary="list toplevels and properties thereof">
       The purpose of this protocol is to enable clients such as taskbars
       or docks to access a list of opened applications and basic properties
@@ -103,7 +103,7 @@
     </event>
   </interface>
 
-  <interface name="zcosmic_toplevel_handle_v1" version="2">
+  <interface name="zcosmic_toplevel_handle_v1" version="3">
     <description summary="an open toplevel">
       A zcosmic_toplevel_handle_v1 object represents an open toplevel
       window. A single app may have multiple open toplevels.
@@ -188,7 +188,7 @@
       <arg name="output" type="object" interface="wl_output"/>
     </event>
 
-    <event name="workspace_enter">
+    <event name="workspace_enter" deprecated-since="3">
       <description summary="toplevel entered an workspace">
         This event is emitted whenever the toplevel becomes visible on the
         given workspace. A toplevel may be visible on multiple workspaces.
@@ -196,7 +196,7 @@
       <arg name="workspace" type="object" interface="zcosmic_workspace_handle_v1"/>
     </event>
 
-    <event name="workspace_leave">
+    <event name="workspace_leave" deprecated-since="3">
       <description summary="toplevel left an workspace">
         This event is emitted whenever the toplevel is no longer visible
         on a given workspace. It is guaranteed that an workspace_enter event with
@@ -240,6 +240,23 @@
       <arg name="y" type="int" summary="y coordinate of the upper-left corner"/>
       <arg name="width" type="int" summary="width of the toplevel"/>
       <arg name="height" type="int" summary="height of the toplevel"/>
+    </event>
+
+    <event name="ext_workspace_enter" since="3">
+      <description summary="toplevel entered an workspace">
+        This event is emitted whenever the toplevel becomes visible on the
+        given workspace. A toplevel may be visible on multiple workspaces.
+      </description>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="ext_workspace_leave" since="3">
+      <description summary="toplevel left an workspace">
+        This event is emitted whenever the toplevel is no longer visible
+        on a given workspace. It is guaranteed that an workspace_enter event with
+        the same workspace has been emitted before this event.
+      </description>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
     </event>
   </interface>
 </protocol>

--- a/unstable/cosmic-toplevel-management-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-management-unstable-v1.xml
@@ -28,7 +28,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zcosmic_toplevel_manager_v1" version="3">
+  <interface name="zcosmic_toplevel_manager_v1" version="4">
     <description summary="control open apps">
       This protocol allows clients such as a taskbar to request the compositor
       to preform typical actions on open toplevels. The compositor is in all
@@ -51,6 +51,7 @@
       <entry name="fullscreen" value="5" summary="set_fullscreen and unset_fullscreen requests are available"/>
       <entry name="move_to_workspace" value="6" since="2" summary="move_to_workspace request is available"/>
       <entry name="sticky" value="7" since="3" summary="set_sticky and unset_sticky requests are available"/>
+      <entry name="move_to_ext_workspace" value="8" since="4" summary="move_to_ext_workspace request is available"/>
     </enum>
 
     <event name="capabilities">
@@ -169,7 +170,7 @@
       <arg name="height" type="int"/>
     </request>
 
-    <request name = "move_to_workspace" since="2">
+    <request name = "move_to_workspace" since="2"  deprecated-since="4">
       <description summary="move toplevel to workspace">
         Move window to workspace, on given output.
       </description>
@@ -192,6 +193,15 @@
         zcosmic_toplevel_handle_v1.state event will be sent.
       </description>
       <arg name="toplevel" type="object" interface="zcosmic_toplevel_handle_v1"/>
+    </request>
+
+    <request name = "move_to_ext_workspace" since="4">
+      <description summary="move toplevel to workspace">
+        Move window to workspace, on given output.
+      </description>
+      <arg name="toplevel" type="object" interface="zcosmic_toplevel_handle_v1"/>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
     </request>
 
     <enum name="error">

--- a/unstable/cosmic-workspace-unstable-v2.xml
+++ b/unstable/cosmic-workspace-unstable-v2.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cosmic_workspace_unstable_v2">
+  <copyright>
+    Copyright © 2025 System76
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zcosmic_workspace_manager_v2" version="1">
+    <description summary="list and control workspaces">
+      This protocol extends `ext-workspace-v1` with addtional requests and events.
+
+      The caller should call `get_cosmic_workspace` whenever a new ext workspace is
+      created.
+    </description>
+
+    <request name="get_cosmic_workspace" since="2">
+      <description summary="get cosmic workspace extension object">
+        Request a `zcosmic_workspace_handle_v2` extension object for an existing
+        `ext_workspace_handle_v1`.
+
+        If a `zcosmic_workspace_handle_v2` already exists for the `ext_workspace_handle_v1`, this
+        will raise a `workspace_exists` protocol error.
+      </description>
+      <arg name="cosmic_workspace" type="new_id" interface="zcosmic_workspace_handle_v2"/>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zcosmic_workspace_manager_v2 object">
+        This request should be called either when the client will no longer
+        use the `zcosmic_workspace_manager_v2`.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="workspace_exists" value="0" summary="zcosmic_workspace_handle_v2 already exists for ext_workspace_handle_v1"/>
+    </enum>
+  </interface>
+
+  <interface name="zcosmic_workspace_handle_v2" version="1">
+    <description summary="a workspace handing a group of surfaces">
+      A zcosmic_workspace_handle_v2 object represents a a workspace that handles a
+      group of surfaces.
+
+      Each workspace has a name, conveyed to the client with the name event; a
+      list of states, conveyed to the client with the state event; and
+      optionally a set of coordinates, conveyed to the client with the
+      coordinates event. The client may request that the compositor activate or
+      deactivate the workspace.
+
+      Each workspace can belong to only a single workspace group.
+      Depepending on the compositor policy, there might be workspaces with
+      the same name in different workspace groups, but these workspaces are still
+      separate (e.g. one of them might be active while the other is not).
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zcosmic_workspace_handle_v1 object">
+        This request should be called either when the client will no longer
+        use the `zcosmic_workspace_handle_v1`.
+      </description>
+    </request>
+
+    <enum name="workspace_capabilities" bitfield="true">
+      <entry name="rename" value="1" summary="rename request is available"/>
+      <entry name="set_tiling_state" value="2" summary="set_tiling_state request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for removing workspaces, a button
+        triggering the remove request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for remove will ignore
+        remove requests.
+
+        Compositors must send this event once after creation of a
+        `zcosmic_workspace_handle_v2`. When the capabilities change, compositors
+        must send this event again.
+      </description>
+      <arg name="capabilities" type="uint" summary="capabilities" enum="workspace_capabilities"/>
+    </event>
+
+    <event name="tiling_state">
+      <description summary="indicates if tiling behavior is enabled for this workspace">
+        This event is emitted immediately after the zcosmic_workspace_handle_v2 is created
+        and each time the workspace tiling state changes, either because of a
+        compositor action or because of a request in this protocol.
+      </description>
+      <arg name="state" type="uint" enum="tiling_state"/>
+    </event>
+
+    <enum name="tiling_state">
+      <description summary="types of tiling state a workspace may have"/>
+
+      <entry name="floating_only" value="0" summary="The workspace has no active tiling properties"/>
+      <entry name="tiling_enabled" value="1" summary="Tiling behavior is enabled for the workspace"/>
+    </enum>
+
+    <request name="rename">
+      <description summary="rename this workspace">
+        Request that this workspace is renamed.
+
+        There is no guarantee the workspace will actually be renamed.
+      </description>
+      <arg name="name" type="string" summary="new name of the workspace"/>
+    </request>
+
+    <request name="set_tiling_state">
+      <description summary="change the tiling state of this workspace">
+        Request that this workspace's tiling state is changed.
+
+        There is no guarantee the workspace will actually change it's tiling state.
+      </description>
+      <arg name="state" type="uint" enum="tiling_state" summary="the new tiling state of the workspace"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
Needs cctk changes, and cosmic-comp support.

Updating the cctk abstraction handle both protocols may be a bit awkward. Perhaps like https://github.com/pop-os/cosmic-protocols/pull/46, it needs an enum wrapper over handles. `Workspace.state` could be changed to the ext type. While `capabilities` needs to be wrapped/split in some way.

This requires changes to the toplevel_info/toplevel_management protocols to use ext handles.