### PR TITLE
a11y: Add new protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,14 @@ DATADIR=$${datarootdir}
 DATAROOTDIR=$${prefix}/share
 
 unstable_protocols = \
+	unstable/cosmic-a11y-unstable-v1.xml \
+	unstable/cosmic-atspi-unstable-v1.xml \
 	unstable/cosmic-image-source-unstable-v1.xml \
-	unstable/cosmic-screencopy-unstable-v2.xml \
 	unstable/cosmic-output-management-unstable-v1.xml \
+	unstable/cosmic-overlap-notify-unstable-v1.xml \
+	unstable/cosmic-screencopy-unstable-v2.xml \
 	unstable/cosmic-toplevel-info-unstable-v1.xml \
 	unstable/cosmic-toplevel-management-unstable-v1.xml \
-	unstable/cosmic-overlap-notify-unstable-v1.xml \
 	unstable/cosmic-workspace-unstable-v1.xml \
 
 check: $(unstable_protocols)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,30 @@
 #[macro_use]
 mod protocol_macro;
 
+pub mod a11y {
+    //! Accessibility support.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./unstable/cosmic-a11y-unstable-v1.xml",
+            []
+        );
+    }
+}
+
+pub mod atspi {
+    //! Atspi accessibility support.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./unstable/cosmic-atspi-unstable-v1.xml",
+            []
+        );
+    }
+}
+
 pub mod image_source {
     //! Capture interface.
 
@@ -96,18 +120,6 @@ pub mod workspace {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-workspace-unstable-v1.xml",
-            []
-        );
-    }
-}
-
-pub mod atspi {
-    //! Atspi accessibility support.
-
-    #[allow(missing_docs)]
-    pub mod v1 {
-        wayland_protocol!(
-            "./unstable/cosmic-atspi-unstable-v1.xml",
             []
         );
     }

--- a/unstable/cosmic-a11y-unstable-v1.xml
+++ b/unstable/cosmic-a11y-unstable-v1.xml
@@ -1,0 +1,50 @@
+<protocol name="cosmic_a11y_v1">
+  <copyright>
+    Copyright © 2025 System76
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="toggle various accessibility features">
+    This protocols provides way to toggle various accessibility features
+    in the COSMIC desktop environment for shell components.
+  </description>
+
+  <interface name="cosmic_a11y_manager_v1" version="1">
+    <description summary="a11y global">
+      Manager to toggle accessibility features.
+    </description>
+
+    <event name="magnifier">
+      <description summary="State of the screen magnifier"/>
+      <arg name="active" type="uint" enum="active_state" summary="If the screen magnifier is enabled"/>
+    </event>
+
+    <request name="set_magnifier">
+      <description summary="Set the screen magnifier on or off"/>
+      <arg name="active" type="uint" enum="active_state" summary="If the screen magnifier should be enabled"/>
+    </request>
+
+    <enum name="active_state">
+        <entry name="disabled" value="0" summary="function is disabled"/>
+        <entry name="enabled" value="1" summary="function is enabled"/>
+    </enum>
+  </interface>
+</protocol>


### PR DESCRIPTION
New protocol for the upcoming accessibility applet.

For now this is only the home or requests to enable/disable the screen magnifier.

I would assume https://github.com/pop-os/cosmic-comp/pull/1058 would also use this in a similar fashion:

```
    <event name="screen_filter">
      <description summary="State of the screen filter"/>
      <arg name="active" type="uint" enum="active_state" summary="If a screen filter is enabled"/>
      <arg name="filter" type="uint" enum="filter" summary="Which filter is selected"/>
    </event>

    <request name="set_screen_filter">
      <description summary="Set the screen filter"/>
      <arg name="active" type="uint" enum="active_state" summary="If the screen filter should be enabled"/>
      <arg name="filter" type="uint" enum="filter" summary="Which filter should be used"/>
    </request>

    <enum name="filter">
        <entry name="unknown" value="0" summary="Custom screen filter"/>
        <entry name="invert" value="1" summary="Inverted colors"/>
        <entry name="greyscale" value="2" summary="Greyscale colors"/>
        <entry name="daltonize-deuteranopia" value="3" summary="Daltonize for Deuteranopia"/>
        <entry name="daltonize-protanopia" value="4" summary="Daltonize for Protanopia"/>
        <entry name="daltonize-tritanopia" value="5" summary="Daltonize for Tritanopia"/>
    </enum>
```

However given this functionality isn't ready yet and I don't want to expose it in the protocol before it is, we should just add these with a minor version bump later in my opinion.

The rest of the [accessibility applet functionality](https://www.figma.com/design/yJFqMXZ8Ge1qs4eKZDDtj3/Accessibility?node-id=20-14930&p=f&t=bHFinpi0EeRUNXgB-0) should also easily fit in here and the vast majority of these involve the compositor anyhow and for the rest this also provides a nice way to synchronize state.