### PR TITLE
 client-toolkit/workspace: Add workspace/group `_info` methods

### DIFF
--- a/client-toolkit/src/workspace.rs
+++ b/client-toolkit/src/workspace.rs
@@ -125,10 +125,32 @@ impl WorkspaceState {
             .filter_map(|data| data.current.as_ref())
     }
 
+    pub fn workspace_group_info(
+        &self,
+        handle: &ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    ) -> Option<&WorkspaceGroup> {
+        self.workspace_groups
+            .iter()
+            .find(|g| g.handle == *handle)?
+            .current
+            .as_ref()
+    }
+
     pub fn workspaces(&self) -> impl Iterator<Item = &Workspace> {
         self.workspaces
             .iter()
             .filter_map(|data| data.current.as_ref())
+    }
+
+    pub fn workspace_info(
+        &self,
+        handle: &ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    ) -> Option<&Workspace> {
+        self.workspaces
+            .iter()
+            .find(|g| g.handle == *handle)?
+            .current
+            .as_ref()
     }
 }
 


### PR DESCRIPTION
Equivalent to the `ToplevelInfoState::info` method for toplevels. So now the workspace and toplevel helpers have similar APIs.

This is quite helpful now that workspace groups only contain a set of workspace handles, not info, and need to be looked up.

(From a performance standpoint, just a linear search through an array is likely as fast as anything with the number of workspaces that are likely to exist, so this implementation should be fine.)