### PR TITLE
WIP toplevel_info: PID and security context

### DIFF
--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -41,6 +41,8 @@ pub struct ToplevelInfo {
     /// Requires zcosmic_toplevel_info_v1 version 2
     pub cosmic_toplevel: Option<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1>,
     pub foreign_toplevel: ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    /// Requires zcosmic_toplevel_info_v1 version 4
+    pub pid: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -62,6 +64,7 @@ impl ToplevelData {
             workspace: HashSet::new(),
             cosmic_toplevel: None,
             foreign_toplevel,
+            pid: None,
         };
         Self {
             current_info: None,
@@ -119,7 +122,7 @@ impl ToplevelInfoState {
         let cosmic_toplevel_info = registry
             .bind_one::<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, _, _>(
                 qh,
-                2..=3,
+                2..=4,
                 GlobalData,
             )
             .ok();
@@ -284,6 +287,11 @@ where
                         height,
                     },
                 );
+            }
+            zcosmic_toplevel_handle_v1::Event::Pid {
+                pid
+            } => {
+                data.pending_info.pid = Some(pid);
             }
             // Not used in protocol version 2
             zcosmic_toplevel_handle_v1::Event::AppId { .. }

--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -27,7 +27,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zcosmic_toplevel_info_v1" version="3">
+  <interface name="zcosmic_toplevel_info_v1" version="4">
     <description summary="list toplevels and properties thereof">
       The purpose of this protocol is to enable clients such as taskbars
       or docks to access a list of opened applications and basic properties
@@ -257,6 +257,16 @@
         the same workspace has been emitted before this event.
       </description>
       <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="pid" since="4">
+      <arg name="pid", type="uint"/>
+    </event>
+
+    <event name="security_context" since="4">
+      <arg name="sandbox_engine", type="string" allow-null="true"/>
+      <arg name="app_id", type="string" allow-null="true"/>
+      <arg name="instance_id", type="string" allow-null="true"/>
     </event>
   </interface>
 </protocol>


### PR DESCRIPTION
The xdg-desktop-portal-gnome background portal uses the `sandbox_app_id` from the `org.gnome.Shell.Introspect` protocol to get the app ID of flatpak/snap apps.

Mutter implements this by getting the PID of the Wayland or X11 client, then accessing `/proc/$PID/root/.flatpak-info`. (Or something else for Snaps.)

If we want to do the same, it's probably easier to have the compositor expose the PID (which may also be useful for other purposes), and then let our portal do any further lookups.

For Wayland apps, `security-context-v1` is probably a more robust way to get the sandboxing information, but presumably we still need a PID-based approach for X11 clients. So it would be good to expose that too.

Pid of course is potentially racy. But a pidfd would still be racy in the compositor, since we'd have to create it from a PID, and it wouldn't work on non-Linux platforms. Races probably aren't a problem if the client immediately looks up the process after the compositor adversities the window, and the compositor will remove windows immediately when the client is gone (assuming the process that created the socket is the only one with it open).

We should probably also have a field to indicate that the client uses X11. Maybe an `xid` field. Though like PID, this is potentially racy.