### PR TITLE
fix wrong interface name ext_foreign_toplevel_*list*_v1

### DIFF
--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -33,7 +33,7 @@
       or docks to access a list of opened applications and basic properties
       thereof.
 
-      It thus extends ext_foreign_toplevel_v1 to provide more information
+      It thus extends ext_foreign_toplevel_list_v1 to provide more information
       and actions on foreign toplevels.
     </description>
 


### PR DESCRIPTION
ext_foreign_toplevel_v1 => ext_foreign_toplevel_list_v1

See: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml?ref_type=heads#L54