### PR TITLE
Update `sctk` and migrate to Rust 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -11,30 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Setup Editorconfig
         uses: editorconfig-checker/action-editorconfig-checker@main
       - name: Editorconfig
         run: editorconfig-checker
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           override: true
-          profile: minimal
           components: rustfmt
-          default: true
       - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   c-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y wayland-protocols libexpat1-dev libffi-dev libxml2-dev ninja-build meson
       - name: Latest wayland-scanner
@@ -54,18 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           override: true
-          profile: minimal
-          default: true
       - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   doc:
     runs-on: ubuntu-latest
@@ -73,21 +64,19 @@ jobs:
       - rust-check
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           override: true
       - name: Build Documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
+        run: cargo doc
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html
       - name: Deploy
         if: ${{ github.event_name == 'push' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-protocols"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 documentation = "https://pop-os.github.io/cosmic-protocols/"
 repository = "https://github.com/pop-os/cosmic-protocols"
 authors = ["Victoria Brekenfeld <github@drakulix.de>"]
@@ -12,26 +12,29 @@ categories = ["gui", "api-bindings"]
 readme = "README.md"
 
 [dependencies]
-wayland-scanner = "0.31.0"
-wayland-backend = "0.3.1"
-wayland-protocols = { version = "0.32.6", features = ["staging"] }
-wayland-protocols-wlr = "0.3.1"
-wayland-client = { version = "0.31.1", optional = true }
-wayland-server = { version = "0.31.0", optional = true }
-bitflags = "2.4"
+wayland-scanner = "0.31.7"
+wayland-backend = "0.3.11"
+wayland-protocols = { version = "0.32.9", features = ["staging"] }
+wayland-protocols-wlr = "0.3.9"
+wayland-client = { version = "0.31.11", optional = true }
+wayland-server = { version = "0.31.10", optional = true }
+bitflags = "2.9"
 
 [dev-dependencies]
-async-channel = "1.7.1"
-cascade = "1"
-env_logger = "0.10.0"
-smithay = { git = "https://github.com/Smithay/smithay", rev = "298a3ec", default-features = false, features = ["backend_egl", "renderer_gl", "renderer_multi"]}
-wayland-backend = { version = "0.3.1", features = ["client_system"] }
-memfd = "0.6.1"
+wayland-backend = { version = "0.3.11", features = ["client_system"] }
 
 [features]
 default = ["client", "server"]
-client = ["wayland-client", "wayland-protocols/client", "wayland-protocols-wlr/client"]
-server = ["wayland-server", "wayland-protocols/server", "wayland-protocols-wlr/server"]
+client = [
+    "wayland-client",
+    "wayland-protocols/client",
+    "wayland-protocols-wlr/client",
+]
+server = [
+    "wayland-server",
+    "wayland-protocols/server",
+    "wayland-protocols-wlr/server",
+]
 
 [workspace]
 members = ["client-toolkit"]

--- a/client-toolkit/Cargo.toml
+++ b/client-toolkit/Cargo.toml
@@ -1,30 +1,24 @@
 [package]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cosmic-protocols = { path = "../" }
-sctk = { package = "smithay-client-toolkit", version = "0.19.1" }
-wayland-client = { version = "0.31.1" }
-libc = "0.2.153"
-wayland-protocols = { version = "0.32.4", features = ["client", "staging"] }
-bitflags = "2.8.0"
+sctk = { package = "smithay-client-toolkit", version = "0.20.0" }
+wayland-client = { version = "0.31.11" }
+libc = "0.2.175"
+wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
+bitflags = "2.9.3"
 
 [dev-dependencies]
-futures = "0.3.24"
-cascade = "1"
-env_logger = "0.10.0"
-gdk-pixbuf = "0.18.0"
-glow = "0.12.0"
-iced = { version = "0.10.0", features = ["image"] }
-nix = { version = "0.27.0", features = ["fs"] }
-png = "0.17.5"
-raw-window-handle = "0.5.0"
-wayland-backend = { version = "0.3.2", features = ["client_system"] }
-winit = "0.28.0"
+png = "0.18.0"
+wayland-backend = { version = "0.3.11", features = ["client_system"] }
 gbm = "0.18.0"
-smithay = { version = "0.7.0", default-features = false, features = ["renderer_gl", "backend_drm"] }
+smithay = { version = "0.7.0", default-features = false, features = [
+    "renderer_gl",
+    "backend_drm",
+] }
 
 [features]
 default = []

--- a/client-toolkit/examples/screenshot-screencopy-dma.rs
+++ b/client-toolkit/examples/screenshot-screencopy-dma.rs
@@ -13,8 +13,8 @@ use smithay::{
         allocator::dmabuf::Dmabuf,
         egl::{EGLContext, EGLDevice, EGLDisplay},
         renderer::{
-            gles::{GlesRenderer, GlesTexture},
             ExportMem, ImportDma,
+            gles::{GlesRenderer, GlesTexture},
         },
     },
     utils::Rectangle,
@@ -26,10 +26,9 @@ use std::{
     sync::Mutex,
 };
 use wayland_client::{
-    delegate_noop,
+    Connection, QueueHandle, WEnum, delegate_noop,
     globals::registry_queue_init,
     protocol::{wl_buffer, wl_output},
-    Connection, QueueHandle, WEnum,
 };
 use wayland_protocols::wp::linux_dmabuf::zv1::client::{
     zwp_linux_buffer_params_v1::{self, ZwpLinuxBufferParamsV1},

--- a/client-toolkit/examples/screenshot-screencopy.rs
+++ b/client-toolkit/examples/screenshot-screencopy.rs
@@ -6,14 +6,13 @@ use cosmic_client_toolkit::screencopy::{
 use sctk::{
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
-    shm::{raw::RawPool, Shm, ShmHandler},
+    shm::{Shm, ShmHandler, raw::RawPool},
 };
 use std::{fs, io, sync::Mutex};
 use wayland_client::{
-    delegate_noop,
+    Connection, QueueHandle, WEnum, delegate_noop,
     globals::registry_queue_init,
     protocol::{wl_buffer, wl_output, wl_shm},
-    Connection, QueueHandle, WEnum,
 };
 
 struct AppData {

--- a/client-toolkit/examples/toplevel-monitor.rs
+++ b/client-toolkit/examples/toplevel-monitor.rs
@@ -3,7 +3,7 @@ use sctk::{
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
 };
-use wayland_client::{globals::registry_queue_init, protocol::wl_output, Connection, QueueHandle};
+use wayland_client::{Connection, QueueHandle, globals::registry_queue_init, protocol::wl_output};
 use wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1;
 
 struct AppData {

--- a/client-toolkit/examples/workspaces.rs
+++ b/client-toolkit/examples/workspaces.rs
@@ -4,7 +4,7 @@ use sctk::{
     registry::{ProvidesRegistryState, RegistryState},
 };
 use wayland_client::{
-    globals::registry_queue_init, protocol::wl_output, Connection, Proxy, QueueHandle,
+    Connection, Proxy, QueueHandle, globals::registry_queue_init, protocol::wl_output,
 };
 
 struct AppData {

--- a/client-toolkit/src/screencopy/capture_source.rs
+++ b/client-toolkit/src/screencopy/capture_source.rs
@@ -1,6 +1,6 @@
 use cosmic_protocols::image_source::v1::client::zcosmic_image_source_v1;
 use std::{error::Error, fmt};
-use wayland_client::{protocol::wl_output, Dispatch, Proxy, QueueHandle};
+use wayland_client::{Dispatch, Proxy, QueueHandle, protocol::wl_output};
 use wayland_protocols::ext::{
     foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
     image_capture_source::v1::client::ext_image_capture_source_v1,
@@ -8,7 +8,7 @@ use wayland_protocols::ext::{
 };
 
 use super::Capturer;
-use crate::{toplevel_info::ToplevelUserData, GlobalData};
+use crate::{GlobalData, toplevel_info::ToplevelUserData};
 
 #[derive(Debug)]
 pub struct CaptureSourceError(CaptureSourceKind);

--- a/client-toolkit/src/screencopy/dispatch/cosmic.rs
+++ b/client-toolkit/src/screencopy/dispatch/cosmic.rs
@@ -8,7 +8,7 @@ use cosmic_protocols::{
     },
 };
 use std::time::Duration;
-use wayland_client::{protocol::wl_shm, Connection, Dispatch, QueueHandle, WEnum};
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum, protocol::wl_shm};
 
 use super::super::{
     CaptureFrame, CaptureSession, Rect, ScreencopyFrameDataExt, ScreencopyHandler,

--- a/client-toolkit/src/screencopy/mod.rs
+++ b/client-toolkit/src/screencopy/mod.rs
@@ -15,9 +15,9 @@ use std::{
     time::Duration,
 };
 use wayland_client::{
+    Connection, Dispatch, Proxy, QueueHandle, WEnum,
     globals::GlobalList,
     protocol::{wl_buffer, wl_output::Transform, wl_shm},
-    Connection, Dispatch, Proxy, QueueHandle, WEnum,
 };
 use wayland_protocols::ext::{
     image_capture_source::v1::client::{

--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -7,7 +7,7 @@ use cosmic_protocols::toplevel_info::v1::client::{
     zcosmic_toplevel_handle_v1, zcosmic_toplevel_info_v1,
 };
 use sctk::registry::RegistryState;
-use wayland_client::{protocol::wl_output, Connection, Dispatch, Proxy, QueueHandle, Weak};
+use wayland_client::{Connection, Dispatch, Proxy, QueueHandle, Weak, protocol::wl_output};
 use wayland_protocols::ext::{
     foreign_toplevel_list::v1::client::{
         ext_foreign_toplevel_handle_v1, ext_foreign_toplevel_list_v1,

--- a/client-toolkit/src/workspace.rs
+++ b/client-toolkit/src/workspace.rs
@@ -3,7 +3,7 @@ use cosmic_protocols::workspace::v2::client::{
 };
 use sctk::registry::{GlobalProxy, RegistryState};
 use std::collections::HashSet;
-use wayland_client::{protocol::wl_output, Connection, Dispatch, QueueHandle, WEnum};
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum, protocol::wl_output};
 use wayland_protocols::ext::workspace::v1::client::{
     ext_workspace_group_handle_v1, ext_workspace_handle_v1, ext_workspace_manager_v1,
 };

--- a/examples/toplevel-list.rs
+++ b/examples/toplevel-list.rs
@@ -6,9 +6,8 @@ use cosmic_protocols::{
     },
 };
 use wayland_client::{
-    event_created_child,
+    Connection, Dispatch, Proxy, QueueHandle, event_created_child,
     protocol::{wl_output, wl_registry},
-    Connection, Dispatch, Proxy, QueueHandle,
 };
 
 #[derive(Default)]
@@ -357,8 +356,7 @@ fn main() {
                     .iter()
                     .flat_map(|(_, w)| w.iter())
                     .find(|(o, _)| o == obj)
-                    .map(|(_, name)| name)
-                )
+                    .map(|(_, name)| name))
                 .collect::<Vec<_>>(),
         );
     }


### PR DESCRIPTION
Updates `sctk` to `0.20.0` and migrates to Rust 2024. Updates dependencies and removes unused ones.

Also updates CI.yml (might potentially need tweaks, but not sure until it runs).

The `sctk` update should hopefully allow removing the patching needed currently.

Doesn't seem to cause any regressions with a patched `cosmic-panel`.