### PR TITLE
Resilience for already closed windows at toplevel (#1)

### DIFF
--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -351,12 +351,15 @@ where
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let data = &mut state
+        let Some(data) = state
             .toplevel_info_state()
             .toplevels
             .iter_mut()
             .find(|data| data.foreign_toplevel() == handle)
-            .expect("Received event for dead toplevel");
+        else {
+            // In case of not finding, it means that the window is already closed
+            return;
+        };
         match event {
             ext_foreign_toplevel_handle_v1::Event::Closed => {
                 state.toplevel_closed(conn, qh, handle);


### PR DESCRIPTION
***NOTE***
I'm not used to Rust, and definitely not with Wayland/Iced/Cosmic, but i experienced this problem when using ashell (a custom bar package for Wayland, was using on Hyprland)

*Ashell*:https://github.com/MalpenZibo/ashell
*iced*: https://github.com/pop-os/iced
I had the following stack trace, a panic when trying to close a window that was previously closed to the system tray:

`ERROR [ashell] Panic: panicked at /home/cally/.cargo/git/checkouts/cosmic-protocols-1292b541ae7bfaf6/d0e95be/client-toolkit/src/toplevel_info.rs:359:14:
Received event for dead toplevel
0: ashell::main::{{closure}}::{{closure}}
at ./src/main.rs:76:17
1: std::panicking::rust_panic_with_hook
2: std::panicking::begin_panic_handler::{{closure}}
3: std::sys::backtrace::__rust_end_short_backtrace
4: __rustc::rust_begin_unwind
5: core::panicking::panic_fmt
6: core::option::expect_failed
7: core::option::Option::expect
at /usr/src/debug/rust/rustc-1.89.0-src/library/core/src/option.rs:960:21
8: <cosmic_client_toolkit::toplevel_info::ToplevelInfoState as wayland_client::event_queue::Dispatch<wayland_protocols::ext::foreign_toplevel_list::v1::generated::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,cosmic_client_toolkit::toplevel_info::ToplevelUserData,D>>::event
at /home/cally/.cargo/git/checkouts/cosmic-protocols-1292b541ae7bfaf6/d0e95be/client-toolkit/src/toplevel_info.rs:359:14
9: iced_winit::platform_specific::wayland::handlers::toplevel::<impl wayland_client::event_queue::Dispatch<wayland_protocols::ext::foreign_toplevel_list::v1::generated::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,cosmic_client_toolkit::toplevel_info::ToplevelUserData> for iced_winit::platform_specific::wayland::event_loop::state::SctkState>::event
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-client-0.31.11/src/event_queue.rs:808:17
10: wayland_client::event_queue::queue_callback
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-client-0.31.11/src/event_queue.rs:660:5
11: wayland_client::event_queue::EventQueue::dispatching_impl
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-client-0.31.11/src/event_queue.rs:482:13
12: wayland_client::event_queue::EventQueue::dispatch_pending
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-client-0.31.11/src/event_queue.rs:388:9
13: iced_winit::platform_specific::wayland::event_loop::SctkEventLoop::new::{{closure}}::{{closure}}
at /home/cally/.cargo/git/checkouts/iced-a711726c6f80dbab/00c31a8/winit/src/platform_specific/wayland/event_loop/mod.rs:261:47
14: <core::cell::RefCell<calloop::sources::DispatcherInner<S,F>> as calloop::sources::EventDispatcher>::process_events::{{closure}}
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/calloop-0.14.3/src/sources/mod.rs:327:61
15: calloop_wayland_source::WaylandSource::loop_callback_pending
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/calloop-wayland-source-0.4.1/src/lib.rs:245:19
16: <calloop_wayland_source::WaylandSource as calloop::sources::EventSource>::process_events
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/calloop-wayland-source-0.4.1/src/lib.rs:154:9
17: <core::cell::RefCell<calloop::sources::DispatcherInner<S,F>> as calloop::sources::EventDispatcher>::process_events
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/calloop-0.14.3/src/sources/mod.rs:327:14
18: calloop::loop_logic::EventLoop::dispatch_events
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/calloop-0.14.3/src/loop_logic.rs:527:36
19: calloop::loop_logic::EventLoop::dispatch
at /home/cally/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/calloop-0.14.3/src/loop_logic.rs:632:14
20: iced_winit::platform_specific::wayland::event_loop::SctkEventLoop::new::{{closure}}
at /home/cally/.cargo/git/checkouts/iced-a711726c6f80dbab/00c31a8/winit/src/platform_specific/wayland/event_loop/mod.rs:442:38
21: std::sys::backtrace::_rust_begin_short_backtrace
at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/sys/backtrace.rs:152:18
22: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/thread/mod.rs:559:17
23: <core::panic::unwind_safe::AssertUnwindSafe as core::ops::function::FnOnce<()>>::call_once
at /usr/src/debug/rust/rustc-1.89.0-src/library/core/src/panic/unwind_safe.rs:272:9
24: std::panicking::catch_unwind::do_call
at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/panicking.rs:589:40
25: _rust_try
26: std::panicking::catch_unwind
at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/panicking.rs:552:19
27: std::panic::catch_unwind
at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/panic.rs:359:14
28: std::thread::Builder::spawn_unchecked::{{closure}}
at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/thread/mod.rs:557:30
29: core::ops::function::FnOnce::call_once{{vtable.shim}}
at /usr/src/debug/rust/rustc-1.89.0-src/library/core/src/ops/function.rs:250:5
30: std::sys::pal::unix::thread::Thread::new::thread_start
31:
32:`

This pull request was the way i could prevent the panic from happening, adding resilience on trying to handle a window that was already closed

I would deeply appreciate opinions and contributions on this pull request, or alternatives to solving the problem