### PR TITLE
Handle stale Wayland toplevel events without panicking

### DIFF
--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -226,12 +226,14 @@ where
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
-        let data = &mut state
+        let Some(data) = state
             .toplevel_info_state()
             .toplevels
             .iter_mut()
             .find(|data| data.cosmic_toplevel() == Some(toplevel))
-            .expect("Received event for dead toplevel");
+        else {
+            return;
+        };
         match event {
             zcosmic_toplevel_handle_v1::Event::OutputEnter { output } => {
                 data.pending_info.output.insert(output);
@@ -351,12 +353,14 @@ where
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let data = &mut state
+        let Some(data) = state
             .toplevel_info_state()
             .toplevels
             .iter_mut()
             .find(|data| data.foreign_toplevel() == handle)
-            .expect("Received event for dead toplevel");
+        else {
+            return;
+        };
         match event {
             ext_foreign_toplevel_handle_v1::Event::Closed => {
                 state.toplevel_closed(conn, qh, handle);


### PR DESCRIPTION
Replace the `.expect("Received event for dead toplevel")` calls in `ZcosmicToplevelHandleV1` and `ExtForeignToplevelHandleV1` dispatchers with early returns so that we gracefully ignore events that target already-dropped toplevels.

Keep the behavior otherwise unchanged.

In practice (see ashell reports), Wayland can deliver `Title`, `AppId`, `OutputEnter`, etc., after the corresponding `ext_foreign_toplevel_handle_v1::Event::Closed` has already removed the entry from **toplevels**. 
The previous `.expect` therefore panicked with:
```
thread 'main' panicked at 'Received event for dead toplevel'
```

Patching **cosmic-client-toolkit** to tolerate these stale events eliminates the crash; multiple testers have confirmed the patched build resolves their issue (see https://github.com/MalpenZibo/ashell/pull/375). 
This addresses race conditions noted in issues: 
https://github.com/MalpenZibo/ashell/issues/446
https://github.com/MalpenZibo/ashell/issues/343
https://github.com/MalpenZibo/ashell/issues/305
https://github.com/MalpenZibo/ashell/issues/178

**Testing**

Built the dependent application with this patch and verified it no longer panics when rapidly opening/closing windows (per ashell testers) in 
https://github.com/MalpenZibo/ashell/issues/446
https://github.com/MalpenZibo/ashell/issues/343

PS: 
haven't seen
https://github.com/pop-os/cosmic-protocols/pull/71

@Drakulix thx