### PR TITLE
client-toolkit/screencopy: Add `CaptureCursorSession::data()`

### DIFF
--- a/client-toolkit/src/screencopy/mod.rs
+++ b/client-toolkit/src/screencopy/mod.rs
@@ -272,6 +272,10 @@ impl CaptureCursorSession {
             }
         })))
     }
+
+    pub fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
+        self.0.session.data()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Matches `CaptureSession` and `CaptureFrame`.