### PR TITLE
corner-radius: Add popup/layer-shell support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod corner_radius {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-corner-radius-unstable-v1.xml",
-            [wayland_protocols::xdg::shell]
+            [wayland_protocols::xdg::shell, wayland_protocols_wlr::layer_shell::v1]
         );
     }
 }

--- a/unstable/cosmic-corner-radius-unstable-v1.xml
+++ b/unstable/cosmic-corner-radius-unstable-v1.xml
@@ -216,8 +216,8 @@
 
         The value is given in logical space relative to the remaining size of the
         associated zwlr_layer_surface_v1 after any said padding was applied.
-        If any value exceeds a quarter of either dimension of the size the
-        radius_too_large protocol error is raised.
+        If any value exceeds half of the respective dimension of the remaining size
+        the radius_too_large protocol error is raised.
       </description>
       <arg name="top_left" type="uint" summary="top-left corner radius" />
       <arg name="top_right" type="uint" summary="top-right corner radius" />
@@ -247,7 +247,7 @@
         the size of the associated zwlr_layer_surface and in the case of the top and left padding
         added to the layer position before applying the corner radius. Negative padding values are allowed.
 
-        If any value exceeds half of either dimension of the surface size the padding_too_large
+        If any value exceeds half of the respective dimension of the surface size the padding_too_large
         protocol error is raised.
       </description>
       <arg name="top" type="int" summary="top padding" />

--- a/unstable/cosmic-corner-radius-unstable-v1.xml
+++ b/unstable/cosmic-corner-radius-unstable-v1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <protocol name="cosmic_corner_radius_v1">
   <copyright>
     Copyright © 2024 System76
@@ -76,6 +76,10 @@
 
         If the given xdg_surface already has a cosmic_corner_radius_toplevel_v1 object associated,
         the corner_radius_exists protocol error will be raised.
+
+        It is an error submitting this request for a xdg+surface object, that doesn't have a role
+        associated yet. (See `xdg_surface::get_toplevel` or `xdg_surface::get_popup`.) A no_role
+        protocol error will be raised in this case.
       </description>
       <arg
         name="id"
@@ -118,6 +122,10 @@
       <entry
         name="corner_radius_exists"
         value="0"
+        summary="the surface already has a corner-radius object"
+      /><entry
+        name="no_role"
+        value="1"
         summary="the surface already has a corner-radius object"
       />
     </enum>

--- a/unstable/cosmic-corner-radius-unstable-v1.xml
+++ b/unstable/cosmic-corner-radius-unstable-v1.xml
@@ -31,9 +31,9 @@
     or prevent overdrawing of other server-side drawn interfaces.
   </description>
 
-  <interface name="cosmic_corner_radius_manager_v1" version="1">
+  <interface name="cosmic_corner_radius_manager_v1" version="2">
     <description summary="corner radius global">
-      Manager for creating corner-radius objects for existing toplevels
+      Manager for creating corner-radius objects for existing surfaces
     </description>
 
     <request name="destroy" type="destructor">
@@ -43,22 +43,83 @@
       </description>
     </request>
 
-    <request name="get_corner_radius">
-      <description summary="Create a new corner-radius object for an existing toplevel">
+    <request name="get_corner_radius" deprecated-since="2">
+      <description
+        summary="Create a new corner-radius object for an existing toplevel"
+      >
         Instantiate an interface extension for the given xdg_toplevel to specify their corner radius.
 
         If the given xdg_toplevel already has a cosmic_corner_radius_toplevel_v1 object associated,
         the corner_radius_exists protocol error will be raised.
+
+        Deprecated: Use `get_corner_radius_surface` instead.
       </description>
-      <arg name="id" type="new_id" interface="cosmic_corner_radius_toplevel_v1"
-        summary="the new cosmic_corner_radius_toplevel_v1 object"/>
-      <arg name="toplevel" type="object" interface="xdg_toplevel"
-        summary="the toplevel"/>
+      <arg
+        name="id"
+        type="new_id"
+        interface="cosmic_corner_radius_toplevel_v1"
+        summary="the new cosmic_corner_radius_toplevel_v1 object"
+      />
+      <arg
+        name="toplevel"
+        type="object"
+        interface="xdg_toplevel"
+        summary="the toplevel"
+      />
+    </request>
+
+    <request name="get_corner_radius_surface" since="2">
+      <description
+        summary="Create a new corner-radius object for an existing xdg-surface"
+      >
+        Instantiate an interface extension for the given xdg_surface to specify their corner radius.
+
+        If the given xdg_surface already has a cosmic_corner_radius_toplevel_v1 object associated,
+        the corner_radius_exists protocol error will be raised.
+      </description>
+      <arg
+        name="id"
+        type="new_id"
+        interface="cosmic_corner_radius_toplevel_v1"
+        summary="the new cosmic_corner_radius_toplevel_v1 object"
+      />
+      <arg
+        name="surface"
+        type="object"
+        interface="xdg_surface"
+        summary="the surface"
+      />
+    </request>
+
+    <request name="get_corner_radius_layer" since="2">
+      <description
+        summary="Create a new corner-radius object for an existing layer"
+      >
+        Instantiate an interface extension for the given layer-surface to specify their corner radius.
+
+        If the given layer-suface already has a cosmic_corner_radius_layer_v1 object associated,
+        the corner_radius_exists protocol error will be raised.
+      </description>
+      <arg
+        name="id"
+        type="new_id"
+        interface="cosmic_corner_radius_layer_v1"
+        summary="the new cosmic_corner_radius_layer_v1 object"
+      />
+      <arg
+        name="layer"
+        type="object"
+        interface="zwlr_layer_surface_v1"
+        summary="the layer surface"
+      />
     </request>
 
     <enum name="error">
-      <entry name="corner_radius_exists" value="0"
-        summary="the toplevel already has a corner-radius object"/>
+      <entry
+        name="corner_radius_exists"
+        value="0"
+        summary="the surface already has a corner-radius object"
+      />
     </enum>
   </interface>
 
@@ -90,10 +151,14 @@
         associated xdg_toplevel. If any value exceeds a quarter of either dimension
         of the window geometry the radius_too_large protocol error is raised.
       </description>
-      <arg name="top_left" type="uint" summary="top-left corner radius"/>
-      <arg name="top_right" type="uint" summary="top-right corner radius"/>
-      <arg name="bottom_right" type="uint" summary="bottom-right corner radius"/>
-      <arg name="bottom_left" type="uint" summary="bottom-left corner radius"/>
+      <arg name="top_left" type="uint" summary="top-left corner radius" />
+      <arg name="top_right" type="uint" summary="top-right corner radius" />
+      <arg
+        name="bottom_right"
+        type="uint"
+        summary="bottom-right corner radius"
+      />
+      <arg name="bottom_left" type="uint" summary="bottom-left corner radius" />
     </request>
 
     <request name="unset_radius">
@@ -104,10 +169,108 @@
     </request>
 
     <enum name="error">
-      <entry name="toplevel_destroyed" value="0"
-        summary="the associated toplevel object has been already destroyed"/>
-      <entry name="radius_too_large" value="1"
-        summary="the associated toplevel's window geometry isn't large enough for the requested radius"/>
+      <entry
+        name="toplevel_destroyed"
+        value="0"
+        summary="the associated toplevel object has been already destroyed"
+      />
+      <entry
+        name="radius_too_large"
+        value="1"
+        summary="the associated toplevel's window geometry isn't large enough for the requested radius"
+      />
+    </enum>
+  </interface>
+
+  <interface name="cosmic_corner_radius_layer_v1" version="1">
+    <description summary="corner radius layer">
+      The corner-radius object provides a way to specify a corner-radius
+      for it's associated layer surface.
+
+      If the zwlr_layer_surface_v1 associated with the cosmic_corner_radius_layer_v1
+      object has been destroyed, this object becomes inert. Any further requests
+      other than destroy will raise the layer_destroyed protocol error.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the corner-radius object">
+        Informs the server that the client will no longer be using this protocol
+        object. The corner radius will be unset on the next commit.
+      </description>
+    </request>
+
+    <request name="set_radius">
+      <description summary="Set corner radius">
+        This request sets the hinted corner radius values for rectangular layers.
+
+        The corner radius hint is double-buffered state and will be applied on
+        the next wl_surface.commit.
+
+        The value is given in logical space relative to the remaining size of the
+        associated zwlr_layer_surface_v1 after any said padding was applied.
+        If any value exceeds a quarter of either dimension of the size the
+        radius_too_large protocol error is raised.
+      </description>
+      <arg name="top_left" type="uint" summary="top-left corner radius" />
+      <arg name="top_right" type="uint" summary="top-right corner radius" />
+      <arg
+        name="bottom_right"
+        type="uint"
+        summary="bottom-right corner radius"
+      />
+      <arg name="bottom_left" type="uint" summary="bottom-left corner radius" />
+    </request>
+
+    <request name="unset_radius">
+      <description summary="Unset corner radius">
+        Unsets any previously hinted corner radius values without invalidating the object for later use.
+        Can be used by clients that possibly have temporary irregular shapes.
+      </description>
+    </request>
+
+    <request name="set_padding">
+      <description summary="Set edge padding">
+        This request sets the hinted padding values for rectangular layers.
+
+        The padding hint is double-buffered state and will be applied on
+        the next wl_surface.commit.
+
+        The value is given in logical space as the amount of pixels to subtract from
+        the size of the associated zwlr_layer_surface and in the case of the top and left padding
+        added to the layer position before applying the corner radius. Negative padding values are allowed.
+
+        If any value exceeds half of either dimension of the surface size the padding_too_large
+        protocol error is raised.
+      </description>
+      <arg name="top" type="int" summary="top padding" />
+      <arg name="right" type="int" summary="right padding" />
+      <arg name="bottom" type="int" summary="bottom left padding" />
+      <arg name="left" type="int" summary="left padding" />
+    </request>
+
+    <request name="unset_padding">
+      <description summary="Unset edge padding">
+        Unsets any previously hinted padding values without invalidating the object for later use.
+        Can be used by clients that possibly have temporary irregular shapes.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry
+        name="layer_destroyed"
+        value="0"
+        summary="the associated layer surface object has been already destroyed"
+      />
+      <entry
+        name="radius_too_large"
+        value="1"
+        summary="the associated layer's size isn't large enough for the requested radius"
+      />
+      <entry
+        name="padding_too_large"
+        value="2"
+        summary="the associated layer's size isn't large enough for the requested padding"
+      />
     </enum>
   </interface>
 </protocol>


### PR DESCRIPTION
v2 of the corner radius protocol doing two things:
- bring the protocol inline with ext-surface-shape by allowing `cosmic_corner_radius_toplevel_v1` (not renaming this one for less disruption) to be created from an xdg-surface to also allow popups to be clipped.
- adding `cosmic_corner_radius_layer_v1`, which does the same for layer-surfaces, but also allows to specify padding values for a lack of a "window geometry" of layer-surfaces. (We can revisit this when ext-layer-surface lands, which might introduce geometry.)