### PR TITLE
docs: doc_auto_cfg feature removed in Rust 1.92

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 


### PR DESCRIPTION
This is now included in the doc_cfg feature. Needed to generate documentation with `RUSTDOCFLAGS="--cfg docsrs"` on Rust 1.92+.