### PR TITLE
feat: add toplevel window icons

### DIFF
--- a/client-toolkit/src/screencopy/capture_source.rs
+++ b/client-toolkit/src/screencopy/capture_source.rs
@@ -8,9 +8,20 @@ use wayland_protocols::ext::{
 
 use super::Capturer;
 use crate::GlobalData;
+use cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CaptureSourceError(CaptureSourceKind);
+
+impl CaptureSourceError {
+    pub(crate) fn new(kind: CaptureSourceKind) -> Self {
+        Self(kind)
+    }
+
+    pub fn kind(&self) -> CaptureSourceKind {
+        self.0
+    }
+}
 
 impl fmt::Display for CaptureSourceError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -24,6 +35,7 @@ impl Error for CaptureSourceError {}
 pub enum CaptureSourceKind {
     Output,
     Toplevel,
+    ToplevelIcon,
     Workspace,
 }
 
@@ -31,7 +43,25 @@ pub enum CaptureSourceKind {
 pub enum CaptureSource {
     Output(wl_output::WlOutput),
     Toplevel(ExtForeignToplevelHandleV1),
+    ToplevelIcon(ToplevelIconCaptureSource),
     Workspace(ExtWorkspaceHandleV1),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ToplevelIconCaptureSource {
+    pub(crate) toplevel: ZcosmicToplevelHandleV1,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+impl ToplevelIconCaptureSource {
+    pub(crate) fn new(toplevel: ZcosmicToplevelHandleV1, width: u32, height: u32) -> Self {
+        Self {
+            toplevel,
+            width,
+            height,
+        }
+    }
 }
 
 impl CaptureSource {
@@ -39,6 +69,7 @@ impl CaptureSource {
         match self {
             Self::Output(_) => CaptureSourceKind::Output,
             Self::Toplevel(_) => CaptureSourceKind::Toplevel,
+            Self::ToplevelIcon(_) => CaptureSourceKind::ToplevelIcon,
             Self::Workspace(_) => CaptureSourceKind::Workspace,
         }
     }
@@ -67,6 +98,14 @@ impl CaptureSource {
                     ));
                 }
             }
+            CaptureSource::ToplevelIcon(icon) => {
+                return Ok(WlCaptureSource(icon.toplevel.create_icon_source(
+                    icon.width,
+                    icon.height,
+                    qh,
+                    GlobalData,
+                )));
+            }
             CaptureSource::Workspace(workspace) => {
                 if let Some(manager) = &capturer.0.workspace_source_manager {
                     return Ok(WlCaptureSource(
@@ -75,7 +114,7 @@ impl CaptureSource {
                 }
             }
         }
-        Err(CaptureSourceError(self.kind()))
+        Err(CaptureSourceError::new(self.kind()))
     }
 }
 

--- a/client-toolkit/src/screencopy/dispatch.rs
+++ b/client-toolkit/src/screencopy/dispatch.rs
@@ -149,26 +149,30 @@ where
             }
             ext_image_copy_capture_frame_v1::Event::Ready => {
                 let frame = frame.lock().unwrap().clone();
-                app_data.ready(
-                    conn,
-                    qh,
-                    &CaptureFrame {
-                        frame: screencopy_frame.clone(),
-                    },
-                    frame,
-                );
-                screencopy_frame.destroy();
+                let capture_frame = CaptureFrame {
+                    frame: screencopy_frame.clone(),
+                    lifecycle: udata
+                        .screencopy_frame_data()
+                        .lifecycle
+                        .get()
+                        .unwrap()
+                        .clone(),
+                };
+                app_data.ready(conn, qh, &capture_frame, frame);
+                capture_frame.destroy();
             }
             ext_image_copy_capture_frame_v1::Event::Failed { reason } => {
-                app_data.failed(
-                    conn,
-                    qh,
-                    &CaptureFrame {
-                        frame: screencopy_frame.clone(),
-                    },
-                    reason,
-                );
-                screencopy_frame.destroy();
+                let capture_frame = CaptureFrame {
+                    frame: screencopy_frame.clone(),
+                    lifecycle: udata
+                        .screencopy_frame_data()
+                        .lifecycle
+                        .get()
+                        .unwrap()
+                        .clone(),
+                };
+                app_data.failed(conn, qh, &capture_frame, reason);
+                capture_frame.destroy();
             }
             _ => unreachable!(),
         }

--- a/client-toolkit/src/screencopy/mod.rs
+++ b/client-toolkit/src/screencopy/mod.rs
@@ -1,6 +1,9 @@
 use cosmic_protocols::image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1;
 use std::{
-    sync::{Arc, Mutex, OnceLock, Weak},
+    sync::{
+        Arc, Mutex, OnceLock, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 use wayland_client::{
@@ -25,6 +28,7 @@ pub use ext_image_copy_capture_manager_v1::Options as CaptureOptions;
 use crate::GlobalData;
 
 mod capture_source;
+pub(crate) use capture_source::ToplevelIconCaptureSource;
 pub use capture_source::{CaptureSource, CaptureSourceError, CaptureSourceKind};
 mod dispatch;
 
@@ -91,7 +95,21 @@ impl Drop for CapturerInner {
 pub struct Capturer(Arc<CapturerInner>);
 
 impl Capturer {
-    // TODO check supported capture types
+    /// Returns whether the compositor advertises image-copy-capture support.
+    pub fn can_capture(&self) -> bool {
+        self.0.image_copy_capture_manager.is_some()
+    }
+
+    fn capture_manager(
+        &self,
+        kind: CaptureSourceKind,
+    ) -> Result<&ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, CaptureSourceError>
+    {
+        self.0
+            .image_copy_capture_manager
+            .as_ref()
+            .ok_or_else(|| CaptureSourceError::new(kind))
+    }
 
     pub fn create_session<D, U>(
         &self,
@@ -106,6 +124,7 @@ impl Capturer {
         D: Dispatch<ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1, U>,
         U: ScreencopySessionDataExt + Send + Sync + 'static,
     {
+        let manager = self.capture_manager(source.kind())?;
         let source = source.create_source(self, qh)?;
         Ok(CaptureSession(Arc::new_cyclic(|weak_session| {
             udata
@@ -114,12 +133,7 @@ impl Capturer {
                 .set(weak_session.clone())
                 .unwrap();
             CaptureSessionInner {
-                session: self
-                    .0
-                    .image_copy_capture_manager
-                    .as_ref()
-                    .expect("ext capture source with no image capture copy manager")
-                    .create_session(&source.0, options, qh, udata),
+                session: manager.create_session(&source.0, options, qh, udata),
             }
         })))
     }
@@ -140,6 +154,7 @@ impl Capturer {
             >,
         U: ScreencopyCursorSessionDataExt + Send + Sync + 'static,
     {
+        let manager = self.capture_manager(source.kind())?;
         let source = source.create_source(self, qh)?;
         Ok(CaptureCursorSession(Arc::new_cyclic(|weak_session| {
             udata
@@ -148,12 +163,7 @@ impl Capturer {
                 .set(weak_session.clone())
                 .unwrap();
             CaptureCursorSessionInner {
-                session: self
-                    .0
-                    .image_copy_capture_manager
-                    .as_ref()
-                    .expect("ext capture source with no image capture copy manager")
-                    .create_pointer_cursor_session(&source.0, pointer, qh, udata),
+                session: manager.create_pointer_cursor_session(&source.0, pointer, qh, udata),
             }
         })))
     }
@@ -186,10 +196,16 @@ impl CaptureSession {
         D: Dispatch<ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1, U>,
         U: ScreencopyFrameDataExt + Send + Sync + 'static,
     {
+        let lifecycle = Arc::new(FrameLifecycle::default());
         udata
             .screencopy_frame_data()
             .session
             .set(Arc::downgrade(&self.0))
+            .unwrap();
+        udata
+            .screencopy_frame_data()
+            .lifecycle
+            .set(lifecycle.clone())
             .unwrap();
         let frame = self.0.session.create_frame(qh, udata);
         frame.attach_buffer(buffer);
@@ -203,7 +219,7 @@ impl CaptureSession {
             frame.damage_buffer(*x, *y, *width, *height);
         }
         frame.capture();
-        CaptureFrame { frame }
+        CaptureFrame { frame, lifecycle }
     }
 
     pub fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
@@ -211,12 +227,47 @@ impl CaptureSession {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Default)]
+struct FrameLifecycle(AtomicBool);
+
+impl FrameLifecycle {
+    fn destroy(&self, destroy_frame: impl FnOnce()) {
+        if !self.0.swap(true, Ordering::AcqRel) {
+            destroy_frame();
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct CaptureFrame {
     frame: ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1,
+    lifecycle: Arc<FrameLifecycle>,
+}
+
+impl PartialEq for CaptureFrame {
+    fn eq(&self, other: &Self) -> bool {
+        self.frame == other.frame
+    }
+}
+
+impl Eq for CaptureFrame {}
+
+impl std::hash::Hash for CaptureFrame {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.frame.hash(state);
+    }
 }
 
 impl CaptureFrame {
+    /// Cancel an in-flight capture or release a completed frame.
+    ///
+    /// The toolkit also destroys frames automatically after invoking `ready`
+    /// or `failed`. Repeated calls, including calls from those callbacks, are
+    /// ignored.
+    pub fn destroy(&self) {
+        self.lifecycle.destroy(|| self.frame.destroy());
+    }
+
     pub fn session<U: ScreencopyFrameDataExt + Send + Sync + 'static>(
         &self,
     ) -> Option<CaptureSession> {
@@ -398,6 +449,7 @@ impl ScreencopySessionDataExt for ScreencopySessionData {
 pub struct ScreencopyFrameData {
     frame: Mutex<Frame>,
     session: OnceLock<Weak<CaptureSessionInner>>,
+    lifecycle: OnceLock<Arc<FrameLifecycle>>,
 }
 
 pub trait ScreencopyFrameDataExt {

--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::OnceLock,
+    fs::File,
+    io::Read,
+    os::fd::OwnedFd,
+    sync::{Arc, OnceLock},
 };
 
 use cosmic_protocols::toplevel_info::v1::client::{
@@ -25,6 +28,78 @@ pub struct ToplevelGeometry {
     pub height: i32,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ToplevelIcon {
+    Name(Arc<str>),
+    Rgba {
+        width: u32,
+        height: u32,
+        pixels: Arc<[u8]>,
+    },
+}
+
+impl ToplevelIcon {
+    const MAX_DIMENSION: u32 = 512;
+    const MAX_BYTES: usize = 512 * 512 * 4;
+
+    pub fn from_rgba(width: u32, height: u32, pixels: impl Into<Arc<[u8]>>) -> Option<Self> {
+        if width == 0 || height == 0 || width > Self::MAX_DIMENSION || height > Self::MAX_DIMENSION
+        {
+            return None;
+        }
+        let pixels = pixels.into();
+        let len = usize::try_from(width)
+            .ok()?
+            .checked_mul(usize::try_from(height).ok()?)?
+            .checked_mul(4)?;
+        if len > Self::MAX_BYTES || pixels.len() != len {
+            return None;
+        }
+        Some(Self::Rgba {
+            width,
+            height,
+            pixels,
+        })
+    }
+
+    fn from_fd(data: OwnedFd, width: u32, height: u32) -> Option<Self> {
+        let len = usize::try_from(width)
+            .ok()?
+            .checked_mul(usize::try_from(height).ok()?)?
+            .checked_mul(4)?;
+        if width == 0
+            || height == 0
+            || width > Self::MAX_DIMENSION
+            || height > Self::MAX_DIMENSION
+            || len > Self::MAX_BYTES
+        {
+            return None;
+        }
+
+        let mut file = File::from(data);
+        let metadata = file.metadata().ok()?;
+        if !metadata.is_file() || metadata.len() != u64::try_from(len).ok()? {
+            return None;
+        }
+
+        let mut pixels = vec![0; len];
+        file.read_exact(&mut pixels).ok()?;
+        Self::from_rgba(width, height, pixels)
+    }
+}
+
+fn apply_icon_fd(icon: &mut Option<ToplevelIcon>, data: OwnedFd, width: u32, height: u32) -> bool {
+    let Some(new_icon) = ToplevelIcon::from_fd(data, width, height) else {
+        return false;
+    };
+    *icon = Some(new_icon);
+    true
+}
+
+fn apply_pid(current: &mut Option<u32>, pid: u32) {
+    *current = (pid != 0).then_some(pid);
+}
+
 #[derive(Clone, Debug)]
 pub struct ToplevelInfo {
     pub title: String,
@@ -38,6 +113,10 @@ pub struct ToplevelInfo {
     pub geometry: HashMap<wl_output::WlOutput, ToplevelGeometry>,
     /// Requires zcosmic_toplevel_info_v1 version 3
     pub workspace: HashSet<ext_workspace_handle_v1::ExtWorkspaceHandleV1>,
+    /// Requires zcosmic_toplevel_info_v1 version 4
+    pub icon: Option<ToplevelIcon>,
+    /// Requires zcosmic_toplevel_info_v1 version 4
+    pub pid: Option<u32>,
     /// Requires zcosmic_toplevel_info_v1 version 2
     pub cosmic_toplevel: Option<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1>,
     pub foreign_toplevel: ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
@@ -60,6 +139,8 @@ impl ToplevelData {
             output: HashSet::new(),
             geometry: HashMap::new(),
             workspace: HashSet::new(),
+            icon: None,
+            pid: None,
             cosmic_toplevel: None,
             foreign_toplevel,
         };
@@ -111,7 +192,7 @@ impl ToplevelInfoState {
         let cosmic_toplevel_info = registry
             .bind_one::<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, _, _>(
                 qh,
-                2..=3,
+                2..=4,
                 GlobalData,
             )
             .ok();
@@ -276,6 +357,22 @@ where
                         height,
                     },
                 );
+            }
+            zcosmic_toplevel_handle_v1::Event::IconName { icon_name } => {
+                data.pending_info.icon = Some(ToplevelIcon::Name(icon_name.into()));
+            }
+            zcosmic_toplevel_handle_v1::Event::Icon {
+                data: icon_data,
+                width,
+                height,
+            } => {
+                apply_icon_fd(&mut data.pending_info.icon, icon_data, width, height);
+            }
+            zcosmic_toplevel_handle_v1::Event::IconRemoved => {
+                data.pending_info.icon = None;
+            }
+            zcosmic_toplevel_handle_v1::Event::Pid { pid } => {
+                apply_pid(&mut data.pending_info.pid, pid);
             }
             // Not used in protocol version 2
             zcosmic_toplevel_handle_v1::Event::AppId { .. }

--- a/client-toolkit/src/toplevel_info.rs
+++ b/client-toolkit/src/toplevel_info.rs
@@ -1,8 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
-    fs::File,
-    io::Read,
-    os::fd::OwnedFd,
+    error::Error,
+    fmt,
     sync::{Arc, OnceLock},
 };
 
@@ -19,6 +18,7 @@ use wayland_protocols::ext::{
 };
 
 use crate::GlobalData;
+use crate::screencopy::{CaptureSource, ToplevelIconCaptureSource};
 
 #[derive(Clone, Debug, Default)]
 pub struct ToplevelGeometry {
@@ -29,75 +29,75 @@ pub struct ToplevelGeometry {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ToplevelIcon {
-    Name(Arc<str>),
-    Rgba {
-        width: u32,
-        height: u32,
-        pixels: Arc<[u8]>,
-    },
+pub struct ToplevelIcon {
+    /// An icon name following the XDG icon theme specification, when available.
+    pub name: Option<Arc<str>>,
+    generation: u64,
+    toplevel: zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
 }
 
 impl ToplevelIcon {
-    const MAX_DIMENSION: u32 = 512;
-    const MAX_BYTES: usize = 512 * 512 * 4;
+    /// Returns the generation associated with this icon announcement.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
 
-    pub fn from_rgba(width: u32, height: u32, pixels: impl Into<Arc<[u8]>>) -> Option<Self> {
-        if width == 0 || height == 0 || width > Self::MAX_DIMENSION || height > Self::MAX_DIMENSION
-        {
-            return None;
-        }
-        let pixels = pixels.into();
-        let len = usize::try_from(width)
-            .ok()?
-            .checked_mul(usize::try_from(height).ok()?)?
-            .checked_mul(4)?;
-        if len > Self::MAX_BYTES || pixels.len() != len {
-            return None;
-        }
-        Some(Self::Rgba {
+    /// Create a deferred capture source descriptor at the requested dimensions.
+    ///
+    /// The Wayland source request is sent by [`crate::screencopy::Capturer::create_session`]
+    /// and targets the icon current when that request is processed. Callers that
+    /// require the pixels to match this announcement should compare `generation`
+    /// with the latest [`ToplevelInfo::icon_generation`] after capture and retry
+    /// if it changed.
+    pub fn capture_source(
+        &self,
+        width: u32,
+        height: u32,
+    ) -> Result<CaptureSource, ToplevelIconCaptureError> {
+        validate_icon_capture_source(self.toplevel.version(), width, height)?;
+        Ok(CaptureSource::ToplevelIcon(ToplevelIconCaptureSource::new(
+            self.toplevel.clone(),
             width,
             height,
-            pixels,
-        })
-    }
-
-    fn from_fd(data: OwnedFd, width: u32, height: u32) -> Option<Self> {
-        let len = usize::try_from(width)
-            .ok()?
-            .checked_mul(usize::try_from(height).ok()?)?
-            .checked_mul(4)?;
-        if width == 0
-            || height == 0
-            || width > Self::MAX_DIMENSION
-            || height > Self::MAX_DIMENSION
-            || len > Self::MAX_BYTES
-        {
-            return None;
-        }
-
-        let mut file = File::from(data);
-        let metadata = file.metadata().ok()?;
-        if !metadata.is_file() || metadata.len() != u64::try_from(len).ok()? {
-            return None;
-        }
-
-        let mut pixels = vec![0; len];
-        file.read_exact(&mut pixels).ok()?;
-        Self::from_rgba(width, height, pixels)
+        )))
     }
 }
 
-fn apply_icon_fd(icon: &mut Option<ToplevelIcon>, data: OwnedFd, width: u32, height: u32) -> bool {
-    let Some(new_icon) = ToplevelIcon::from_fd(data, width, height) else {
-        return false;
-    };
-    *icon = Some(new_icon);
-    true
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToplevelIconCaptureError {
+    InvalidSize,
+    UnsupportedVersion,
 }
 
-fn apply_pid(current: &mut Option<u32>, pid: u32) {
-    *current = (pid != 0).then_some(pid);
+impl fmt::Display for ToplevelIconCaptureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSize => f.write_str("icon capture dimensions must be non-zero"),
+            Self::UnsupportedVersion => {
+                f.write_str("icon capture requires cosmic toplevel info version 4")
+            }
+        }
+    }
+}
+
+impl Error for ToplevelIconCaptureError {}
+
+fn validate_icon_capture_source(
+    version: u32,
+    width: u32,
+    height: u32,
+) -> Result<(), ToplevelIconCaptureError> {
+    if version < 4 {
+        Err(ToplevelIconCaptureError::UnsupportedVersion)
+    } else if width == 0 || height == 0 {
+        Err(ToplevelIconCaptureError::InvalidSize)
+    } else {
+        Ok(())
+    }
+}
+
+fn next_icon_generation(generation: u64) -> u64 {
+    generation.wrapping_add(1)
 }
 
 #[derive(Clone, Debug)]
@@ -115,8 +115,8 @@ pub struct ToplevelInfo {
     pub workspace: HashSet<ext_workspace_handle_v1::ExtWorkspaceHandleV1>,
     /// Requires zcosmic_toplevel_info_v1 version 4
     pub icon: Option<ToplevelIcon>,
-    /// Requires zcosmic_toplevel_info_v1 version 4
-    pub pid: Option<u32>,
+    /// Changes whenever the icon is replaced or removed.
+    pub icon_generation: u64,
     /// Requires zcosmic_toplevel_info_v1 version 2
     pub cosmic_toplevel: Option<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1>,
     pub foreign_toplevel: ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
@@ -126,7 +126,99 @@ pub struct ToplevelInfo {
 struct ToplevelData {
     current_info: Option<ToplevelInfo>,
     pending_info: ToplevelInfo,
-    has_cosmic_info: bool,
+    committed_info: ToplevelInfo,
+    sync: ToplevelSyncState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SyncAction {
+    None,
+    New,
+    Update,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SyncStream {
+    Cosmic,
+    Foreign,
+}
+
+#[derive(Debug, Default)]
+struct ToplevelSyncState {
+    cosmic_dirty: bool,
+    foreign_dirty: bool,
+    cosmic_done: bool,
+    foreign_done: bool,
+}
+
+impl ToplevelSyncState {
+    fn cosmic_changed(&mut self) {
+        self.cosmic_dirty = true;
+    }
+
+    fn foreign_changed(&mut self) {
+        self.foreign_dirty = true;
+    }
+
+    fn cosmic_needs_commit(&self) -> bool {
+        !self.cosmic_done || self.cosmic_dirty
+    }
+
+    fn foreign_needs_commit(&self) -> bool {
+        !self.foreign_done || self.foreign_dirty
+    }
+
+    fn finish_cosmic(&mut self, initialized: bool) -> SyncAction {
+        let dirty = std::mem::take(&mut self.cosmic_dirty);
+        self.cosmic_done = true;
+        if !initialized && self.foreign_done {
+            SyncAction::New
+        } else if initialized && dirty {
+            SyncAction::Update
+        } else {
+            SyncAction::None
+        }
+    }
+
+    fn finish_foreign(&mut self, initialized: bool) -> SyncAction {
+        let dirty = std::mem::take(&mut self.foreign_dirty);
+        self.foreign_done = true;
+        if !initialized && self.cosmic_done {
+            SyncAction::New
+        } else if initialized && dirty {
+            SyncAction::Update
+        } else {
+            SyncAction::None
+        }
+    }
+}
+
+fn finish_stream<T: Clone>(
+    current: &mut Option<T>,
+    pending: &T,
+    committed: &mut T,
+    sync: &mut ToplevelSyncState,
+    stream: SyncStream,
+    commit_fields: impl Fn(&mut T, &T),
+) -> SyncAction {
+    let needs_commit = match stream {
+        SyncStream::Cosmic => sync.cosmic_needs_commit(),
+        SyncStream::Foreign => sync.foreign_needs_commit(),
+    };
+    if needs_commit {
+        commit_fields(committed, pending);
+    }
+
+    let action = match stream {
+        SyncStream::Cosmic => sync.finish_cosmic(current.is_some()),
+        SyncStream::Foreign => sync.finish_foreign(current.is_some()),
+    };
+    match action {
+        SyncAction::New => *current = Some(committed.clone()),
+        SyncAction::Update => commit_fields(current.as_mut().unwrap(), committed),
+        SyncAction::None => {}
+    }
+    action
 }
 
 impl ToplevelData {
@@ -140,14 +232,15 @@ impl ToplevelData {
             geometry: HashMap::new(),
             workspace: HashSet::new(),
             icon: None,
-            pid: None,
+            icon_generation: 0,
             cosmic_toplevel: None,
             foreign_toplevel,
         };
         Self {
             current_info: None,
+            committed_info: pending_info.clone(),
             pending_info,
-            has_cosmic_info: false,
+            sync: ToplevelSyncState::default(),
         }
     }
 
@@ -158,6 +251,22 @@ impl ToplevelData {
     fn foreign_toplevel(&self) -> &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1 {
         &self.pending_info.foreign_toplevel
     }
+}
+
+fn commit_cosmic_fields(current: &mut ToplevelInfo, pending: &ToplevelInfo) {
+    current.cosmic_toplevel = pending.cosmic_toplevel.clone();
+    current.state.clone_from(&pending.state);
+    current.output.clone_from(&pending.output);
+    current.workspace.clone_from(&pending.workspace);
+    current.geometry.clone_from(&pending.geometry);
+    current.icon.clone_from(&pending.icon);
+    current.icon_generation = pending.icon_generation;
+}
+
+fn commit_foreign_fields(current: &mut ToplevelInfo, pending: &ToplevelInfo) {
+    current.title.clone_from(&pending.title);
+    current.app_id.clone_from(&pending.app_id);
+    current.identifier.clone_from(&pending.identifier);
 }
 
 #[doc(hidden)]
@@ -278,6 +387,37 @@ where
     ) {
         match event {
             zcosmic_toplevel_info_v1::Event::Done => {
+                let updates = {
+                    let info_state = state.toplevel_info_state();
+                    info_state
+                        .toplevels
+                        .iter_mut()
+                        .filter_map(|data| {
+                            let action = finish_stream(
+                                &mut data.current_info,
+                                &data.pending_info,
+                                &mut data.committed_info,
+                                &mut data.sync,
+                                SyncStream::Cosmic,
+                                commit_cosmic_fields,
+                            );
+                            if action == SyncAction::None {
+                                return None;
+                            }
+                            Some((
+                                data.pending_info.foreign_toplevel.clone(),
+                                action == SyncAction::New,
+                            ))
+                        })
+                        .collect::<Vec<_>>()
+                };
+                for (handle, is_new) in updates {
+                    if is_new {
+                        state.new_toplevel(conn, qh, &handle);
+                    } else {
+                        state.update_toplevel(conn, qh, &handle);
+                    }
+                }
                 state.info_done(conn, qh);
             }
             // Not used in protocol version 2
@@ -316,22 +456,25 @@ where
         match event {
             zcosmic_toplevel_handle_v1::Event::OutputEnter { output } => {
                 data.pending_info.output.insert(output);
+                data.sync.cosmic_changed();
             }
             zcosmic_toplevel_handle_v1::Event::OutputLeave { output } => {
                 data.pending_info.output.remove(&output);
                 data.pending_info.geometry.remove(&output);
+                data.sync.cosmic_changed();
             }
             // Ignore legacy workspace handle events
             zcosmic_toplevel_handle_v1::Event::WorkspaceEnter { .. }
             | zcosmic_toplevel_handle_v1::Event::WorkspaceLeave { .. } => {}
             zcosmic_toplevel_handle_v1::Event::ExtWorkspaceEnter { workspace } => {
                 data.pending_info.workspace.insert(workspace);
+                data.sync.cosmic_changed();
             }
             zcosmic_toplevel_handle_v1::Event::ExtWorkspaceLeave { workspace } => {
                 data.pending_info.workspace.remove(&workspace);
+                data.sync.cosmic_changed();
             }
             zcosmic_toplevel_handle_v1::Event::State { state } => {
-                data.has_cosmic_info = true;
                 data.pending_info.state.clear();
                 for value in state.chunks_exact(4) {
                     if let Ok(state) = zcosmic_toplevel_handle_v1::State::try_from(
@@ -340,6 +483,7 @@ where
                         data.pending_info.state.insert(state);
                     }
                 }
+                data.sync.cosmic_changed();
             }
             zcosmic_toplevel_handle_v1::Event::Geometry {
                 output,
@@ -357,22 +501,23 @@ where
                         height,
                     },
                 );
+                data.sync.cosmic_changed();
             }
-            zcosmic_toplevel_handle_v1::Event::IconName { icon_name } => {
-                data.pending_info.icon = Some(ToplevelIcon::Name(icon_name.into()));
-            }
-            zcosmic_toplevel_handle_v1::Event::Icon {
-                data: icon_data,
-                width,
-                height,
-            } => {
-                apply_icon_fd(&mut data.pending_info.icon, icon_data, width, height);
+            zcosmic_toplevel_handle_v1::Event::IconChanged { icon_name } => {
+                data.pending_info.icon_generation =
+                    next_icon_generation(data.pending_info.icon_generation);
+                data.pending_info.icon = Some(ToplevelIcon {
+                    name: icon_name.map(Into::into),
+                    generation: data.pending_info.icon_generation,
+                    toplevel: toplevel.clone(),
+                });
+                data.sync.cosmic_changed();
             }
             zcosmic_toplevel_handle_v1::Event::IconRemoved => {
+                data.pending_info.icon_generation =
+                    next_icon_generation(data.pending_info.icon_generation);
                 data.pending_info.icon = None;
-            }
-            zcosmic_toplevel_handle_v1::Event::Pid { pid } => {
-                apply_pid(&mut data.pending_info.pid, pid);
+                data.sync.cosmic_changed();
             }
             // Not used in protocol version 2
             zcosmic_toplevel_handle_v1::Event::AppId { .. }
@@ -418,7 +563,10 @@ where
                     .cosmic_toplevel
                     .set(cosmic_toplevel.as_ref().map(|t| t.downgrade()))
                     .unwrap();
+                toplevel_data.sync.cosmic_done = cosmic_toplevel.is_none();
                 toplevel_data.pending_info.cosmic_toplevel = cosmic_toplevel;
+                toplevel_data.committed_info.cosmic_toplevel =
+                    toplevel_data.pending_info.cosmic_toplevel.clone();
                 info_state.toplevels.push(toplevel_data);
             }
             ext_foreign_toplevel_list_v1::Event::Finished => {
@@ -467,15 +615,19 @@ where
                 }
             }
             ext_foreign_toplevel_handle_v1::Event::Done => {
-                if data.cosmic_toplevel().is_some() && !data.has_cosmic_info {
-                    // Don't call `new_toplevel` if we have the `ext_foreign_toplevel_handle_v1`,
-                    // but don't have any `zcosmic_toplevel_handle_v1` events yet.
+                let action = finish_stream(
+                    &mut data.current_info,
+                    &data.pending_info,
+                    &mut data.committed_info,
+                    &mut data.sync,
+                    SyncStream::Foreign,
+                    commit_foreign_fields,
+                );
+                if action == SyncAction::None {
                     return;
                 }
 
-                let is_new = data.current_info.is_none();
-                data.current_info = Some(data.pending_info.clone());
-                if is_new {
+                if action == SyncAction::New {
                     state.new_toplevel(conn, qh, handle);
                 } else {
                     state.update_toplevel(conn, qh, handle);
@@ -483,12 +635,15 @@ where
             }
             ext_foreign_toplevel_handle_v1::Event::Title { title } => {
                 data.pending_info.title = title;
+                data.sync.foreign_changed();
             }
             ext_foreign_toplevel_handle_v1::Event::AppId { app_id } => {
                 data.pending_info.app_id = app_id;
+                data.sync.foreign_changed();
             }
             ext_foreign_toplevel_handle_v1::Event::Identifier { identifier } => {
                 data.pending_info.identifier = identifier;
+                data.sync.foreign_changed();
             }
             _ => unreachable!(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub mod toplevel_info {
     pub mod v1 {
         wayland_protocol!(
             "./unstable/cosmic-toplevel-info-unstable-v1.xml",
-            [crate::workspace::v1, wayland_protocols::ext::foreign_toplevel_list::v1, wayland_protocols::ext::workspace::v1]
+            [crate::workspace::v1, wayland_protocols::ext::foreign_toplevel_list::v1, wayland_protocols::ext::image_capture_source::v1, wayland_protocols::ext::workspace::v1]
         );
     }
 }

--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -27,7 +27,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zcosmic_toplevel_info_v1" version="3">
+  <interface name="zcosmic_toplevel_info_v1" version="4">
     <description summary="list toplevels and properties thereof">
       The purpose of this protocol is to enable clients such as taskbars
       or docks to access a list of opened applications and basic properties
@@ -103,7 +103,7 @@
     </event>
   </interface>
 
-  <interface name="zcosmic_toplevel_handle_v1" version="3">
+  <interface name="zcosmic_toplevel_handle_v1" version="4">
     <description summary="an open toplevel">
       A zcosmic_toplevel_handle_v1 object represents an open toplevel
       window. A single app may have multiple open toplevels.
@@ -257,6 +257,47 @@
         the same workspace has been emitted before this event.
       </description>
       <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="icon_name" since="4">
+      <description summary="the toplevel icon name changed">
+        This event is emitted whenever the icon name of the toplevel changes.
+        The icon name follows the XDG icon theme specification. It supersedes
+        any previously sent icon or icon_name event.
+      </description>
+      <arg name="icon_name" type="string"/>
+    </event>
+
+    <event name="icon" since="4">
+      <description summary="the toplevel icon changed">
+        This event is emitted whenever the pixel data of the toplevel icon
+        changes. The pixel data is packed, unpremultiplied RGBA8888. Width and
+        height must each be between 1 and 512 inclusive. The file descriptor
+        refers to a sealed regular file containing exactly width * height * 4
+        bytes and positioned at the beginning of the data. It supersedes any
+        previously sent icon or icon_name event.
+      </description>
+      <arg name="data" type="fd"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="icon_removed" since="4">
+      <description summary="the toplevel icon was removed">
+        This event is emitted whenever the toplevel no longer has an icon. It
+        clears any previously sent icon or icon_name event.
+      </description>
+    </event>
+
+    <event name="pid" since="4">
+      <description summary="the toplevel process identifier changed">
+        This event is emitted once on creation of the
+        zcosmic_toplevel_handle_v1 and again whenever the process identifier of
+        the toplevel changes. A value of zero means that the process identifier
+        is unavailable. This information is advisory and must not be used to
+        make security decisions.
+      </description>
+      <arg name="pid" type="uint"/>
     </event>
   </interface>
 </protocol>

--- a/unstable/cosmic-toplevel-info-unstable-v1.xml
+++ b/unstable/cosmic-toplevel-info-unstable-v1.xml
@@ -259,45 +259,63 @@
       <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
     </event>
 
-    <event name="icon_name" since="4">
-      <description summary="the toplevel icon name changed">
-        This event is emitted whenever the icon name of the toplevel changes.
-        The icon name follows the XDG icon theme specification. It supersedes
-        any previously sent icon or icon_name event.
-      </description>
-      <arg name="icon_name" type="string"/>
-    </event>
-
-    <event name="icon" since="4">
+    <event name="icon_changed" since="4">
       <description summary="the toplevel icon changed">
-        This event is emitted whenever the pixel data of the toplevel icon
-        changes. The pixel data is packed, unpremultiplied RGBA8888. Width and
-        height must each be between 1 and 512 inclusive. The file descriptor
-        refers to a sealed regular file containing exactly width * height * 4
-        bytes and positioned at the beginning of the data. It supersedes any
-        previously sent icon or icon_name event.
+        Sent whenever the icon of the toplevel is replaced. The optional icon_name
+        argument, when non-null, is a name from the XDG icon theme specification
+        that clients may resolve locally. Clients that cannot resolve the name, or
+        that require image data at a specific size, should use create_icon_source to
+        request it. When the compositor accepts image data for the current icon, it
+        must keep a pixel representation obtainable through create_icon_source for
+        as long as that icon remains current, whether or not icon_name is non-null.
+        If no image data was accepted and icon_name is non-null, the compositor
+        should attempt to resolve the name so clients with a different icon-theme or
+        filesystem view can request fallback pixels. When an icon-theme name is
+        available, the compositor should send it in icon_name. The icon name and
+        pixel representation are independent; a non-null icon_name does not
+        guarantee that create_icon_source can produce image data. This event
+        replaces any icon previously announced via icon_changed.
       </description>
-      <arg name="data" type="fd"/>
-      <arg name="width" type="uint"/>
-      <arg name="height" type="uint"/>
+      <arg name="icon_name" type="string" allow-null="true"/>
     </event>
 
     <event name="icon_removed" since="4">
       <description summary="the toplevel icon was removed">
         This event is emitted whenever the toplevel no longer has an icon. It
-        clears any previously sent icon or icon_name event.
+        clears any previously sent icon_changed event.
       </description>
     </event>
 
-    <event name="pid" since="4">
-      <description summary="the toplevel process identifier changed">
-        This event is emitted once on creation of the
-        zcosmic_toplevel_handle_v1 and again whenever the process identifier of
-        the toplevel changes. A value of zero means that the process identifier
-        is unavailable. This information is advisory and must not be used to
-        make security decisions.
+    <enum name="error" since="4">
+      <entry name="invalid_icon_size" value="1"
+        summary="the requested icon dimensions are invalid"/>
+    </enum>
+
+    <request name="create_icon_source" since="4">
+      <description summary="create an image source for the toplevel icon">
+        Creates an image capture source for the current toplevel icon. The
+        requested width and height describe the desired image dimensions and
+        must both be greater than zero. The compositor may scale or rasterize
+        the icon to satisfy the request. If the source icon has a different
+        aspect ratio, it should be fitted without distortion and padded with
+        transparent pixels.
+
+        The source represents the icon current when this request is processed
+        and remains valid if the toplevel icon subsequently changes or the
+        toplevel is destroyed. Clients can use ext_image_copy_capture_v1 to
+        negotiate a format and copy the image into client-owned storage.
+
+        If no pixel representation can be produced, capture sessions created
+        from the source shall be stopped. Resource exhaustion should likewise
+        be reported through the image capture protocol rather than by imposing
+        a fixed maximum icon dimension in this protocol.
+
+        If either dimension is zero, the invalid_icon_size protocol error is
+        raised.
       </description>
-      <arg name="pid" type="uint"/>
-    </event>
+      <arg name="source" type="new_id" interface="ext_image_capture_source_v1"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
   </interface>
 </protocol>


### PR DESCRIPTION
This extends COSMIC toplevel-info to version 4 with icon updates, icon removal and advisory process IDs. Also expose validated icon and PID state through cosmic-client-toolkit.

I noticed that icons and application names are not properly shown for video games launched through Steam in COSMIC dock. This is one of the building blocks to make it work.